### PR TITLE
Raised precedence of `(#)`.

### DIFF
--- a/docs/Prelude.md
+++ b/docs/Prelude.md
@@ -1013,6 +1013,13 @@ instance boundedOrdering :: Bounded Ordering
 ```
 
 
+#### `boundedInt`
+
+``` purescript
+instance boundedInt :: Bounded Int
+```
+
+
 #### `Lattice`
 
 ``` purescript

--- a/src/Prelude.purs
+++ b/src/Prelude.purs
@@ -42,7 +42,7 @@ unit :: Unit
 unit = Unit {}
 
 infixr 0 $
-infixl 0 #
+infixl 1 #
 
 -- | Applies a function to its argument.
 -- |


### PR DESCRIPTION
Couldn't run tests to make sure it works properly, so merge with caution.

Should close #2.
