### PR TITLE
Don't export Unit data constructor

### DIFF
--- a/docs/Prelude.md
+++ b/docs/Prelude.md
@@ -4,7 +4,6 @@
 
 ``` purescript
 newtype Unit
-  = Unit {  }
 ```
 
 ##### Instances
@@ -976,5 +975,6 @@ a human-readable `String` representation.
 While not required, it is recommended that for any expression `x`, the
 string `show x` be executable PureScript code which evaluates to the same
 value as the expression `x`.
+
 
 

--- a/src/Prelude.purs
+++ b/src/Prelude.purs
@@ -1,5 +1,5 @@
 module Prelude
-  ( Unit(..), unit
+  ( Unit(), unit
   , ($), (#)
   , flip
   , const


### PR DESCRIPTION
Exporting the Unit data constructor is a little confusing, and I don't see any harm in removing it from the export list.

I wasn't able to run the tests :( this currently depends on an unreleased version of gulp-purescript, and I couldn't get `npm link` to work.
