### PR TITLE
Export unsafeCompare

### DIFF
--- a/docs/Prelude.md
+++ b/docs/Prelude.md
@@ -975,4 +975,9 @@ instance showArray :: (Show a) => Show (Array a)
 instance showOrdering :: Show Ordering
 ```
 
+#### `unsafeCompare`
 
+``` purescript
+unsafeCompare :: forall a. a -> a -> Ordering
+```
+The `unsafeCompare` function is mainly intended for module writers supporting native types via the FFI, and not for general comparisons.

--- a/src/Prelude.purs
+++ b/src/Prelude.purs
@@ -20,6 +20,7 @@ module Prelude
   , DivisionRing
   , Eq, eq, (==), (/=)
   , Ordering(..), Ord, compare, (<), (>), (<=), (>=)
+  , unsafeCompare
   , Bounded, top, bottom
   , BoundedOrd
   , BooleanAlgebra, conj, disj, not, (&&), (||)


### PR DESCRIPTION
It would be nice to have `unsafeCompare` available to other packages, e.g. for modules providing other backend primitive types through the FFI. It would also be fine to move it to another package if it seems too dangerous to have in the Prelude.

`refEq` and `refIneq` would also be nice to export, but at least they're much simpler functions.
