### PR TITLE
Double backtick Remainder law so that nested backticks are code

### DIFF
--- a/docs/Prelude.md
+++ b/docs/Prelude.md
@@ -634,7 +634,7 @@ multiplication, division, and modulo (division remainder) operations.
 Instances must satisfy the following law in addition to the `Semiring`
 laws:
 
-- Remainder: `a / b * b + (a `mod` b) = a`
+- Remainder: ``a / b * b + (a `mod` b) = a``
 
 ##### Instances
 ``` purescript

--- a/src/Prelude.purs
+++ b/src/Prelude.purs
@@ -515,7 +515,7 @@ foreign import numSub :: Number -> Number -> Number
 -- | Instances must satisfy the following law in addition to the `Semiring`
 -- | laws:
 -- |
--- | - Remainder: `a / b * b + (a `mod` b) = a`
+-- | - Remainder: ``a / b * b + (a `mod` b) = a``
 class (Semiring a) <= ModuloSemiring a where
   div :: a -> a -> a
   mod :: a -> a -> a


### PR DESCRIPTION
Should resolve purescript#1368
