### PR TITLE
Add Bounded Char instance

### DIFF
--- a/docs/Prelude.md
+++ b/docs/Prelude.md
@@ -836,6 +836,12 @@ _left-associative / precedence 4_
 
 Test whether one value is _non-strictly greater than_ another.
 
+#### `unsafeCompare`
+
+``` purescript
+unsafeCompare :: forall a. a -> a -> Ordering
+```
+
 #### `Bounded`
 
 ``` purescript
@@ -860,6 +866,7 @@ instance boundedBoolean :: Bounded Boolean
 instance boundedUnit :: Bounded Unit
 instance boundedOrdering :: Bounded Ordering
 instance boundedInt :: Bounded Int
+instance boundedChar :: Bounded Char
 instance boundedFn :: (Bounded b) => Bounded (a -> b)
 ```
 
@@ -881,6 +888,7 @@ instance boundedOrdBoolean :: BoundedOrd Boolean
 instance boundedOrdUnit :: BoundedOrd Unit
 instance boundedOrdOrdering :: BoundedOrd Ordering
 instance boundedOrdInt :: BoundedOrd Int
+instance boundedOrdChar :: BoundedOrd Char
 ```
 
 #### `BooleanAlgebra`
@@ -975,9 +983,4 @@ instance showArray :: (Show a) => Show (Array a)
 instance showOrdering :: Show Ordering
 ```
 
-#### `unsafeCompare`
 
-``` purescript
-unsafeCompare :: forall a. a -> a -> Ordering
-```
-The `unsafeCompare` function is mainly intended for module writers supporting native types via the FFI, and not for general comparisons.

--- a/src/Prelude.js
+++ b/src/Prelude.js
@@ -172,7 +172,12 @@ exports.unsafeCompareImpl = function (lt) {
   };
 };
 
-//- Lattice --------------------------------------------------------------------
+//- Bounded --------------------------------------------------------------------
+
+exports.topChar = String.fromCharCode(65535);
+exports.bottomChar = String.fromCharCode(0);
+
+//- BooleanAlgebra -------------------------------------------------------------
 
 exports.boolOr = function (b1) {
   return function (b2) {
@@ -185,8 +190,6 @@ exports.boolAnd = function (b1) {
     return b1 && b2;
   };
 };
-
-//- ComplementedLattice --------------------------------------------------------
 
 exports.boolNot = function (b) {
   return !b;

--- a/src/Prelude.purs
+++ b/src/Prelude.purs
@@ -737,9 +737,17 @@ instance boundedInt :: Bounded Int where
   top = 2147483647
   bottom = -2147483648
 
+-- | Characters fall within the Unicode range.
+instance boundedChar :: Bounded Char where
+  top = topChar
+  bottom = bottomChar
+
 instance boundedFn :: (Bounded b) => Bounded (a -> b) where
   top _ = top
   bottom _ = bottom
+
+foreign import topChar :: Char
+foreign import bottomChar :: Char
 
 -- | The `BoundedOrd` type class represents totally ordered finite data types.
 -- |
@@ -752,6 +760,7 @@ instance boundedOrdBoolean :: BoundedOrd Boolean where
 instance boundedOrdUnit :: BoundedOrd Unit where
 instance boundedOrdOrdering :: BoundedOrd Ordering where
 instance boundedOrdInt :: BoundedOrd Int where
+instance boundedOrdChar :: BoundedOrd Char where
 
 -- | The `BooleanAlgebra` type class represents types that behave like boolean
 -- | values.


### PR DESCRIPTION
This was previously an orphan in Data.Char, and also was wrong - the bottom and top values were reversed.

I'm not sure whether this is strictly speaking a breaking change or not, so not sure what we want to do about versioning here.
