### PR TITLE
fix .jshintrc and Travis CI

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -5,7 +5,7 @@
   "freeze": true,
   "funcscope": true,
   "futurehostile": true,
-  "globalstrict": true,
+  "strict": "global",
   "latedef": true,
   "maxparams": 1,
   "noarg": true,


### PR DESCRIPTION
The `globalStrict` option appears to have been deprecated in favour of `strict: "true"` according to [this comment in jshint](https://github.com/jshint/jshint/blob/2e0026f8f461425bb05da966570708002a9f4f0a/src/options.js#L361-L370). This has been the cause of recent Travis CI failures.
