### PR TITLE
Export Unit's constructor for use in pattern matches.

### DIFF
--- a/src/Prelude.purs
+++ b/src/Prelude.purs
@@ -1,5 +1,5 @@
 module Prelude
-  ( Unit(), unit
+  ( Unit(..), unit
   , ($), (#)
   , flip
   , const


### PR DESCRIPTION
I think it's helpful to be able to pattern match on values of type `Unit` (even if we always know what they are) in order to guide type inference in cases such as:

``` purescript
psci> :t \x y z (Unit {}) -> ...
forall t1 t2 t3. t1 -> t2 -> t3 -> Unit -> ...
```

The alternative is having to write `(_ :: Unit)`. This is admittedly only slightly longer, but I don't find the use of a type annotation very natural here. I'd be interested to hear your thoughts.
