### PR TITLE
fixes #65: show implementation for strings/chars containing U+0007

### DIFF
--- a/src/Data/Show.js
+++ b/src/Data/Show.js
@@ -15,7 +15,7 @@ exports.showCharImpl = function (c) {
   var code = c.charCodeAt(0);
   if (code < 0x20 || code === 0x7F) {
     switch (c) {
-      case "\a": return "'\\a'";
+      case "\x07": return "'\\a'";
       case "\b": return "'\\b'";
       case "\f": return "'\\f'";
       case "\n": return "'\\n'";
@@ -37,7 +37,7 @@ exports.showStringImpl = function (s) {
         case "\"":
         case "\\":
           return "\\" + c;
-        case "\a": return "\\a";
+        case "\x07": return "\\a";
         case "\b": return "\\b";
         case "\f": return "\\f";
         case "\n": return "\\n";


### PR DESCRIPTION
`"\a"` in JavaScript is `"a"`, not `"\x07"` like in PureScript/Haskell. Fixes #65.
