### PR TITLE
Add `return` as a synonym for `pure`

### DIFF
--- a/src/Control/Applicative.purs
+++ b/src/Control/Applicative.purs
@@ -1,5 +1,5 @@
 module Control.Applicative
-  ( class Applicative, pure
+  ( class Applicative, pure, return
   , liftA1
   , unless, when
   , module Control.Apply
@@ -31,6 +31,10 @@ import Data.Unit (Unit, unit)
 -- | - Interchange: `u <*> (pure y) = (pure ($ y)) <*> u`
 class Apply f <= Applicative f where
   pure :: forall a. a -> f a
+
+-- | Synonym for `pure`.
+return :: forall m a. Applicative m => a -> m a
+return = pure
 
 instance applicativeFn :: Applicative ((->) r) where
   pure x _ = x

--- a/src/Control/Monad.purs
+++ b/src/Control/Monad.purs
@@ -8,7 +8,7 @@ module Control.Monad
   , module Control.Bind
   ) where
 
-import Control.Applicative (class Applicative, liftA1, pure, unless, when)
+import Control.Applicative (class Applicative, liftA1, pure, return, unless, when)
 import Control.Apply (class Apply, apply, (*>), (<*), (<*>))
 import Control.Bind (class Bind, bind, ifM, join, (<=<), (=<<), (>=>), (>>=))
 

--- a/src/Prelude.purs
+++ b/src/Prelude.purs
@@ -25,7 +25,7 @@ module Prelude
   , module Data.Void
   ) where
 
-import Control.Applicative (class Applicative, pure, liftA1, unless, when)
+import Control.Applicative (class Applicative, pure, return, liftA1, unless, when)
 import Control.Apply (class Apply, apply, (*>), (<*), (<*>))
 import Control.Bind (class Bind, bind, ifM, join, (<=<), (=<<), (>=>), (>>=))
 import Control.Category (class Category, id)


### PR DESCRIPTION
This seems to have gotten dropped between 0.1.5 and 1.0.0-rc.1 -- not sure if this was intentional, but it seems like it ought to remain in, if only to make an upgrade less of a breaking change for people using `return` in do-notation.
