### PR TITLE
Remove redundant imports in Data.Ord

### DIFF
--- a/src/Data/Ord.purs
+++ b/src/Data/Ord.purs
@@ -16,8 +16,6 @@ import Data.Function (on)
 import Data.Ord.Unsafe (unsafeCompare)
 import Data.Ordering (Ordering(..))
 import Data.Ring (negate)
-import Data.Semigroup (class Semigroup)
-import Data.Show (class Show)
 import Data.Unit (Unit)
 import Data.Void (Void)
 


### PR DESCRIPTION
Exactly what it says on the tin: removes two unused imports in `Data.Ord` that `psc` was complaining about.
