### PR TITLE
Re-export && and || from BooleanAlgebra

### DIFF
--- a/src/Data/BooleanAlgebra.purs
+++ b/src/Data/BooleanAlgebra.purs
@@ -3,7 +3,7 @@ module Data.BooleanAlgebra
   , module Data.HeytingAlgebra
   ) where
 
-import Data.HeytingAlgebra (class HeytingAlgebra, ff, tt, implies, conj, disj, not)
+import Data.HeytingAlgebra (class HeytingAlgebra, ff, tt, implies, conj, disj, not, (&&), (||))
 import Data.Unit (Unit)
 
 -- | The `BooleanAlgebra` type class represents types that behave like boolean


### PR DESCRIPTION
This went missing at some point during the updates. `purescript-integers` needs it to build, as of the radix PR being merged.
