### PR TITLE
Remove CommutativeRing constraint from Field

### DIFF
--- a/src/Data/Field.purs
+++ b/src/Data/Field.purs
@@ -15,10 +15,10 @@ import Data.Unit (Unit)
 -- | The `Field` class is for types that are commutative fields.
 -- |
 -- | Instances must satisfy the following law in addition to the
--- | `CommutativeRing` and `EuclideanRing` laws:
+-- | `EuclideanRing` laws:
 -- |
 -- | - Non-zero multiplicative inverse: ``a `mod` b = 0` for all `a` and `b`
-class (CommutativeRing a, EuclideanRing a) <= Field a
+class EuclideanRing a <= Field a
 
 instance fieldNumber :: Field Number
 instance fieldUnit :: Field Unit


### PR DESCRIPTION
This is already implied as `CommutativeRing` is a superclass of `EuclideanRing`. Correspondingly, this shouldn't be a breaking change, right?
