### PR TITLE
Add short motivation of Void type

### DIFF
--- a/src/Data/Void.purs
+++ b/src/Data/Void.purs
@@ -2,6 +2,11 @@ module Data.Void (Void, absurd) where
 
 import Data.Show (class Show)
 
+-- | An uninhabited data type.
+-- |
+-- | `Void` is useful to eliminate the possibility of a value being created.
+-- | For example, a value of type `Either Void Boolean` can never have
+-- | a Left value created in PureScript.
 newtype Void = Void Void
 
 instance showVoid :: Show Void where


### PR DESCRIPTION
I came to Void to decide if I should use it for describing an FFI function: `enable() :: Boolean` - would the arg be `Unit` or `Void`? I had to ask on IRC how Void is intended to be used. Hopefully this short doc answers the question for others coming to it.

I'd like suggestions for better docs for this, also, btw.