### PR TITLE
Add Discard class

### DIFF
--- a/src/Control/Bind.purs
+++ b/src/Control/Bind.purs
@@ -74,10 +74,10 @@ foreign import arrayBind :: forall a b. Array a -> (a -> Array b) -> Array b
 -- | An example is the `Unit` type, since there is only one
 -- | possible value which can be returned.
 class Discard a where
-  discard :: forall f b. Apply f => f a -> (a -> f b) -> f b
+  discard :: forall f b. Bind f => f a -> (a -> f b) -> f b
 
 instance discardUnit :: Discard Unit where
-  discard u f = u *> f unit
+  discard = bind
 
 -- | Collapse two applications of a monadic type constructor into one.
 join :: forall a m. Bind m => m (m a) -> m a

--- a/src/Control/Bind.purs
+++ b/src/Control/Bind.purs
@@ -1,6 +1,7 @@
 module Control.Bind
   ( class Bind, bind, (>>=)
   , bindFlipped, (=<<)
+  , class Discard, discard
   , join
   , composeKleisli, (>=>)
   , composeKleisliFlipped, (<=<)
@@ -16,6 +17,7 @@ import Control.Category (id)
 
 import Data.Function (flip)
 import Data.Functor (class Functor, map, void, ($>), (<#>), (<$), (<$>))
+import Data.Unit (Unit, unit)
 
 -- | The `Bind` type class extends the [`Apply`](#apply) type class with a
 -- | "bind" operation `(>>=)` which composes computations in sequence, using
@@ -65,6 +67,17 @@ instance bindArray :: Bind Array where
   bind = arrayBind
 
 foreign import arrayBind :: forall a b. Array a -> (a -> Array b) -> Array b
+
+-- | A class for types whose values can safely be discarded
+-- | in a `do` notation block.
+-- |
+-- | An example is the `Unit` type, since there is only one
+-- | possible value which can be returned.
+class Discard a where
+  discard :: forall f b. Apply f => f a -> (a -> f b) -> f b
+
+instance discardUnit :: Discard Unit where
+  discard u f = u *> f unit
 
 -- | Collapse two applications of a monadic type constructor into one.
 join :: forall a m. Bind m => m (m a) -> m a

--- a/src/Control/Bind.purs
+++ b/src/Control/Bind.purs
@@ -17,7 +17,7 @@ import Control.Category (id)
 
 import Data.Function (flip)
 import Data.Functor (class Functor, map, void, ($>), (<#>), (<$), (<$>))
-import Data.Unit (Unit, unit)
+import Data.Unit (Unit)
 
 -- | The `Bind` type class extends the [`Apply`](#apply) type class with a
 -- | "bind" operation `(>>=)` which composes computations in sequence, using

--- a/src/Prelude.purs
+++ b/src/Prelude.purs
@@ -28,7 +28,7 @@ module Prelude
 
 import Control.Applicative (class Applicative, pure, liftA1, unless, when)
 import Control.Apply (class Apply, apply, (*>), (<*), (<*>))
-import Control.Bind (class Bind, bind, ifM, join, (<=<), (=<<), (>=>), (>>=))
+import Control.Bind (class Bind, bind, class Discard, discard, ifM, join, (<=<), (=<<), (>=>), (>>=))
 import Control.Category (class Category, id)
 import Control.Monad (class Monad, ap, liftM1, unlessM, whenM)
 import Control.Semigroupoid (class Semigroupoid, compose, (<<<), (>>>))


### PR DESCRIPTION
To support https://github.com/purescript/purescript/issues/1803

I tried a few different approaches, and this one seems nicest. It has the additional benefit that you can now use `do` notation with an arbitrary `Apply`, as long as you discard the results.