### PR TITLE
Remove out of date comment

### DIFF
--- a/src/Data/Field.purs
+++ b/src/Data/Field.purs
@@ -17,10 +17,6 @@ import Data.Semiring (class Semiring, add, mul, one, zero, (*), (+))
 -- | `EuclideanRing` laws:
 -- |
 -- | - Non-zero multiplicative inverse: ``a `mod` b = zero`` for all `a` and `b`
--- |
--- | The `Unit` instance is provided for backwards compatibility, but it is
--- | not law-abiding, because `Unit` does not obey the `EuclideanRing` laws.
--- | This instance will be removed in a future release.
 class EuclideanRing a <= Field a
 
 instance fieldNumber :: Field Number


### PR DESCRIPTION
The `Field Unit` instance was removed with https://github.com/purescript/purescript-prelude/commit/4eb5a275c89ba80a1e9138bb57e1d3ee6663630e#diff-0daf98ff48cd03daf3f176366e341d09L28.