### PR TITLE
Re-add DivisionRing, resolves #128

### DIFF
--- a/src/Data/DivisionRing.purs
+++ b/src/Data/DivisionRing.purs
@@ -1,0 +1,55 @@
+module Data.DivisionRing
+  ( class DivisionRing
+  , recip
+  , leftDiv
+  , rightDiv
+  , module Data.Ring
+  , module Data.Semiring
+  ) where
+
+import Data.Ring (class Ring, negate, sub)
+import Data.Semiring (class Semiring, add, mul, one, zero, (*), (+))
+import Data.EuclideanRing ((/))
+
+-- | The `DivisionRing` class is for non-zero rings in which every non-zero
+-- | element has a multiplicative inverse. Division rings are sometimes also
+-- | called *skew fields*.
+-- |
+-- | Instances must satisfy the following laws in addition to the `Ring` laws:
+-- |
+-- | - Non-zero ring: `one /= zero`
+-- | - Non-zero multiplicative inverse: `recip a * a = a * recip a = one` for
+-- |   all non-zero `a`
+-- |
+-- | The result of `recip zero` is left undefined; individual instances may
+-- | choose how to handle this case.
+-- |
+-- | If a type has both `DivisionRing` and `CommutativeRing` instances, then
+-- | it is a field and should have a `Field` instance.
+class Ring a <= DivisionRing a where
+  recip :: a -> a
+
+-- | Left division, defined as `leftDiv a b = recip b * a`. Left and right
+-- | division are distinct in this module because a `DivisionRing` is not
+-- | necessarily commutative.
+-- |
+-- | If the type `a` is also a `EuclideanRing`, then this function is
+-- | equivalent to `div` from the `EuclideanRing` class. When working
+-- | abstractly, `div` should generally be preferred, unless you know that you
+-- | need your code to work with noncommutative rings.
+leftDiv :: forall a. DivisionRing a => a -> a -> a
+leftDiv a b = recip b * a
+
+-- | Right division, defined as `rightDiv a b = a * recip b`. Left and right
+-- | division are distinct in this module because a `DivisionRing` is not
+-- | necessarily commutative.
+-- |
+-- | If the type `a` is also a `EuclideanRing`, then this function is
+-- | equivalent to `div` from the `EuclideanRing` class. When working
+-- | abstractly, `div` should generally be preferred, unless you know that you
+-- | need your code to work with noncommutative rings.
+rightDiv :: forall a. DivisionRing a => a -> a -> a
+rightDiv a b = a * recip b
+
+instance divisionringNumber :: DivisionRing Number where
+  recip x = 1.0 / x

--- a/src/Data/Field.purs
+++ b/src/Data/Field.purs
@@ -1,22 +1,28 @@
 module Data.Field
   ( class Field
+  , module Data.DivisionRing
   , module Data.CommutativeRing
   , module Data.EuclideanRing
   , module Data.Ring
   , module Data.Semiring
   ) where
 
+import Data.DivisionRing (class DivisionRing, recip)
 import Data.CommutativeRing (class CommutativeRing)
 import Data.EuclideanRing (class EuclideanRing, degree, div, mod, (/), gcd, lcm)
 import Data.Ring (class Ring, negate, sub)
 import Data.Semiring (class Semiring, add, mul, one, zero, (*), (+))
 
--- | The `Field` class is for types that are commutative fields.
+-- | The `Field` class is for types that are (commutative) fields.
 -- |
 -- | Instances must satisfy the following law in addition to the
 -- | `EuclideanRing` laws:
 -- |
 -- | - Non-zero multiplicative inverse: ``a `mod` b = zero`` for all `a` and `b`
+-- |
+-- | If a type has a `Field` instance, it should also have a `DivisionRing`
+-- | instance. In a future release, `DivisionRing` may become a superclass of
+-- | `Field`.
 class EuclideanRing a <= Field a
 
 instance fieldNumber :: Field Number

--- a/src/Prelude.purs
+++ b/src/Prelude.purs
@@ -9,6 +9,7 @@ module Prelude
   , module Data.BooleanAlgebra
   , module Data.Bounded
   , module Data.CommutativeRing
+  , module Data.DivisionRing
   , module Data.Eq
   , module Data.EuclideanRing
   , module Data.Field
@@ -37,6 +38,7 @@ import Data.Boolean (otherwise)
 import Data.BooleanAlgebra (class BooleanAlgebra)
 import Data.Bounded (class Bounded, bottom, top)
 import Data.CommutativeRing (class CommutativeRing)
+import Data.DivisionRing (class DivisionRing, recip)
 import Data.Eq (class Eq, eq, notEq, (/=), (==))
 import Data.EuclideanRing (class EuclideanRing, degree, div, mod, (/), gcd, lcm)
 import Data.Field (class Field)


### PR DESCRIPTION
I also added brackets around the word "commutative" in the description
of the field class so that we can be consistent in terminology (i.e.
using the scheme where "field" = commutative division ring, "skew field"
= noncommutative division ring).

I thought it might be confusing to re-export `leftDiv` and `rightDiv`
from `Prelude`; since they're probably only going to be used very rarely
I thought it would be better to have people import them from
`Data.DivisionRing` if they want to use them.

Also I realised that we have the word "nonzero" with and without a hyphen in various places in this repo. Perhaps we should standardise on one?