### PR TITLE
Add UInt support

### DIFF
--- a/src/Data/Bounded.js
+++ b/src/Data/Bounded.js
@@ -3,5 +3,8 @@
 exports.topInt = 2147483647;
 exports.bottomInt = -2147483648;
 
+exports.bottomUInt = 0;
+exports.topUInt = 4294967295;
+
 exports.topChar = String.fromCharCode(65535);
 exports.bottomChar = String.fromCharCode(0);

--- a/src/Data/Bounded.purs
+++ b/src/Data/Bounded.purs
@@ -29,6 +29,13 @@ instance boundedInt :: Bounded Int where
 foreign import topInt :: Int
 foreign import bottomInt :: Int
 
+instance boundedUInt :: Bounded UInt where
+  top = topUInt
+  bottom = bottomUInt
+
+foreign import topUInt :: UInt
+foreign import bottomUInt :: UInt
+
 -- | Characters fall within the Unicode range.
 instance boundedChar :: Bounded Char where
   top = topChar

--- a/src/Data/CommutativeRing.purs
+++ b/src/Data/CommutativeRing.purs
@@ -18,7 +18,6 @@ import Data.Unit (Unit)
 class Ring a <= CommutativeRing a
 
 instance commutativeRingInt :: CommutativeRing Int
-instance commutativeRingUInt :: CommutativeRing UInt
 instance commutativeRingNumber :: CommutativeRing Number
 instance commutativeRingUnit :: CommutativeRing Unit
 instance commutativeRingFn :: CommutativeRing b => CommutativeRing (a -> b)

--- a/src/Data/CommutativeRing.purs
+++ b/src/Data/CommutativeRing.purs
@@ -18,6 +18,7 @@ import Data.Unit (Unit)
 class Ring a <= CommutativeRing a
 
 instance commutativeRingInt :: CommutativeRing Int
+instance commutativeRingUInt :: CommutativeRing UInt
 instance commutativeRingNumber :: CommutativeRing Number
 instance commutativeRingUnit :: CommutativeRing Unit
 instance commutativeRingFn :: CommutativeRing b => CommutativeRing (a -> b)

--- a/src/Data/Eq.purs
+++ b/src/Data/Eq.purs
@@ -36,6 +36,9 @@ instance eqBoolean :: Eq Boolean where
 instance eqInt :: Eq Int where
   eq = refEq
 
+instance eqUInt :: Eq UInt where
+  eq = refEq
+
 instance eqNumber :: Eq Number where
   eq = refEq
 

--- a/src/Data/EuclideanRing.js
+++ b/src/Data/EuclideanRing.js
@@ -17,6 +17,23 @@ exports.intMod = function (x) {
   };
 };
 
+exports.uintDegree = function (x) {
+  return Math.min(Math.abs(x), 4294967295);
+};
+
+exports.uintDiv = function (x) {
+  return function (y) {
+    /* jshint bitwise: false */
+    return (x / y) <<< 0;
+  };
+};
+
+exports.uintMod = function (x) {
+  return function (y) {
+    return x % y;
+  };
+};
+
 exports.numDiv = function (n1) {
   return function (n2) {
     return n1 / n2;

--- a/src/Data/EuclideanRing.js
+++ b/src/Data/EuclideanRing.js
@@ -24,7 +24,7 @@ exports.uintDegree = function (x) {
 exports.uintDiv = function (x) {
   return function (y) {
     /* jshint bitwise: false */
-    return (x / y) <<< 0;
+    return (x / y) >>> 0;
   };
 };
 

--- a/src/Data/EuclideanRing.js
+++ b/src/Data/EuclideanRing.js
@@ -17,23 +17,6 @@ exports.intMod = function (x) {
   };
 };
 
-exports.uintDegree = function (x) {
-  return Math.min(Math.abs(x), 4294967295);
-};
-
-exports.uintDiv = function (x) {
-  return function (y) {
-    /* jshint bitwise: false */
-    return (x / y) <<< 0;
-  };
-};
-
-exports.uintMod = function (x) {
-  return function (y) {
-    return x % y;
-  };
-};
-
 exports.numDiv = function (n1) {
   return function (n2) {
     return n1 / n2;

--- a/src/Data/EuclideanRing.purs
+++ b/src/Data/EuclideanRing.purs
@@ -42,7 +42,7 @@ import Data.Semiring (class Semiring, add, mul, one, zero, (*), (+))
 -- | reason not to, `Field` types should normally use this definition of
 -- | `degree`.
 class CommutativeRing a <= EuclideanRing a where
-  degree :: a -> UInt
+  degree :: a -> Int
   div :: a -> a -> a
   mod :: a -> a -> a
 
@@ -53,12 +53,17 @@ instance euclideanRingInt :: EuclideanRing Int where
   div = intDiv
   mod = intMod
 
+instance euclideanRingUInt :: EuclideanRing UInt where
+  degree = uintDegree
+  div = uintDiv
+  mod = uintMod
+
 instance euclideanRingNumber :: EuclideanRing Number where
-  degree _ = 1u
+  degree _ = 1
   div = numDiv
   mod _ _ = 0.0
 
-foreign import intDegree :: Int -> UInt
+foreign import intDegree :: Int -> Int
 foreign import intDiv :: Int -> Int -> Int
 foreign import intMod :: Int -> Int -> Int
 

--- a/src/Data/EuclideanRing.purs
+++ b/src/Data/EuclideanRing.purs
@@ -53,6 +53,11 @@ instance euclideanRingInt :: EuclideanRing Int where
   div = intDiv
   mod = intMod
 
+instance euclideanRingUInt :: EuclideanRing UInt where
+  degree = uintDegree
+  div = uintDiv
+  mod = uintMod
+
 instance euclideanRingNumber :: EuclideanRing Number where
   degree _ = 1
   div = numDiv

--- a/src/Data/EuclideanRing.purs
+++ b/src/Data/EuclideanRing.purs
@@ -42,7 +42,7 @@ import Data.Semiring (class Semiring, add, mul, one, zero, (*), (+))
 -- | reason not to, `Field` types should normally use this definition of
 -- | `degree`.
 class CommutativeRing a <= EuclideanRing a where
-  degree :: a -> Int
+  degree :: a -> UInt
   div :: a -> a -> a
   mod :: a -> a -> a
 
@@ -53,17 +53,12 @@ instance euclideanRingInt :: EuclideanRing Int where
   div = intDiv
   mod = intMod
 
-instance euclideanRingUInt :: EuclideanRing UInt where
-  degree = uintDegree
-  div = uintDiv
-  mod = uintMod
-
 instance euclideanRingNumber :: EuclideanRing Number where
-  degree _ = 1
+  degree _ = 1u
   div = numDiv
   mod _ _ = 0.0
 
-foreign import intDegree :: Int -> Int
+foreign import intDegree :: Int -> UInt
 foreign import intDiv :: Int -> Int -> Int
 foreign import intMod :: Int -> Int -> Int
 

--- a/src/Data/EuclideanRing.purs
+++ b/src/Data/EuclideanRing.purs
@@ -42,7 +42,7 @@ import Data.Semiring (class Semiring, add, mul, one, zero, (*), (+))
 -- | reason not to, `Field` types should normally use this definition of
 -- | `degree`.
 class CommutativeRing a <= EuclideanRing a where
-  degree :: a -> Int
+  degree :: a -> UInt
   div :: a -> a -> a
   mod :: a -> a -> a
 
@@ -59,13 +59,17 @@ instance euclideanRingUInt :: EuclideanRing UInt where
   mod = uintMod
 
 instance euclideanRingNumber :: EuclideanRing Number where
-  degree _ = 1
+  degree _ = 1u
   div = numDiv
   mod _ _ = 0.0
 
-foreign import intDegree :: Int -> Int
+foreign import intDegree :: Int -> UInt
 foreign import intDiv :: Int -> Int -> Int
 foreign import intMod :: Int -> Int -> Int
+
+foreign import uintDegree :: UInt -> UInt
+foreign import uintDiv :: UInt -> UInt -> UInt
+foreign import uintMod :: UInt -> UInt -> UInt
 
 foreign import numDiv :: Number -> Number -> Number
 

--- a/src/Data/Ord.purs
+++ b/src/Data/Ord.purs
@@ -39,6 +39,9 @@ instance ordBoolean :: Ord Boolean where
 instance ordInt :: Ord Int where
   compare = unsafeCompare
 
+instance ordUInt :: Ord UInt where
+  compare = unsafeCompare
+
 instance ordNumber :: Ord Number where
   compare = unsafeCompare
 

--- a/src/Data/Ring.js
+++ b/src/Data/Ring.js
@@ -7,6 +7,13 @@ exports.intSub = function (x) {
   };
 };
 
+exports.uintSub = function (x) {
+  return function (y) {
+    /* jshint bitwise: false */
+    return (x - y) >>> 0;
+  };
+};
+
 exports.numSub = function (n1) {
   return function (n2) {
     return n1 - n2;

--- a/src/Data/Ring.purs
+++ b/src/Data/Ring.purs
@@ -21,6 +21,9 @@ infixl 6 sub as -
 instance ringInt :: Ring Int where
   sub = intSub
 
+instance ringUInt :: Ring UInt where
+  sub = uintSub
+
 instance ringNumber :: Ring Number where
   sub = numSub
 
@@ -35,4 +38,5 @@ negate :: forall a. Ring a => a -> a
 negate a = zero - a
 
 foreign import intSub :: Int -> Int -> Int
+foreign import uintSub :: UInt -> UInt -> UInt
 foreign import numSub :: Number -> Number -> Number

--- a/src/Data/Semiring.js
+++ b/src/Data/Semiring.js
@@ -14,6 +14,20 @@ exports.intMul = function (x) {
   };
 };
 
+exports.uintAdd = function (x) {
+  return function (y) {
+    /* jshint bitwise: false */
+    return (x + y) >>> 0;
+  };
+};
+
+exports.uintMul = function (x) {
+  return function (y) {
+    /* jshint bitwise: false */
+    return (x * y) >>> 0;
+  };
+};
+
 exports.numAdd = function (n1) {
   return function (n2) {
     return n1 + n2;

--- a/src/Data/Semiring.purs
+++ b/src/Data/Semiring.purs
@@ -38,6 +38,12 @@ instance semiringInt :: Semiring Int where
   mul = intMul
   one = 1
 
+instance semiringUInt :: Semiring UInt where
+  add = uintAdd
+  zero = 0u
+  mul = uintMul
+  one = 1u
+
 instance semiringNumber :: Semiring Number where
   add = numAdd
   zero = 0.0
@@ -58,5 +64,7 @@ instance semiringUnit :: Semiring Unit where
 
 foreign import intAdd :: Int -> Int -> Int
 foreign import intMul :: Int -> Int -> Int
+foreign import uintAdd :: UInt -> UInt -> UInt
+foreign import uintMul :: UInt -> UInt -> UInt
 foreign import numAdd :: Number -> Number -> Number
 foreign import numMul :: Number -> Number -> Number

--- a/src/Data/Show.js
+++ b/src/Data/Show.js
@@ -4,6 +4,10 @@ exports.showIntImpl = function (n) {
   return n.toString();
 };
 
+exports.showUIntImpl = function (n) {
+  return n.toString() + "u";
+}
+
 exports.showNumberImpl = function (n) {
   var str = n.toString();
   return isNaN(str + ".0") ? str : str + ".0";

--- a/src/Data/Show.purs
+++ b/src/Data/Show.purs
@@ -16,6 +16,9 @@ instance showBoolean :: Show Boolean where
 instance showInt :: Show Int where
   show = showIntImpl
 
+instance showUInt :: Show UInt where
+  show = showUIntImpl
+
 instance showNumber :: Show Number where
   show = showNumberImpl
 
@@ -29,6 +32,7 @@ instance showArray :: Show a => Show (Array a) where
   show = showArrayImpl show
 
 foreign import showIntImpl :: Int -> String
+foreign import showUIntImpl :: UInt -> String
 foreign import showNumberImpl :: Number -> String
 foreign import showCharImpl :: Char -> String
 foreign import showStringImpl :: String -> String

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -58,6 +58,7 @@ testOrderings = do
     assert "NaN > 1 should be false" $ (nan > 1.0) == false
     assert "NaN < 1 should be false" $ (nan < 1.0) == false
     assert "NaN == 1 should be false" $ nan /= 1.0
+    testOrd 1u 3u LT
     testOrd intNan 2147483647 GT
     testOrd 'a' 'b' LT
     testOrd 'b' 'A' GT
@@ -85,7 +86,7 @@ testOrdUtils = do
 testIntDegree :: AlmostEff
 testIntDegree = do
     let bot = bottom :: Int
-    assert "degree returns absolute integers" $ degree (-4) == 4
-    assert "degree returns absolute integers" $ degree 4 == 4
-    assert "degree returns absolute integers" $ degree bot >= 0
+    assert "degree returns absolute integers" $ degree (-4) == 4u
+    assert "degree returns absolute integers" $ degree 4 == 4u
+    assert "degree returns absolute integers" $ degree bot >= 0u
     assert "degree does not return out-of-bounds integers" $ degree bot <= top


### PR DESCRIPTION
This PR adds instances and support for the `UInt` prim type added in [this compiler PR](https://github.com/purescript/purescript/pull/3169#issuecomment-351932284).