### PR TITLE
Add `Monoid` class & newtypes, `Semigroup` newtypes

### DIFF
--- a/src/Data/Monoid.purs
+++ b/src/Data/Monoid.purs
@@ -1,0 +1,67 @@
+module Data.Monoid
+  ( class Monoid, mempty
+  , power
+  , guard
+  , module Data.Semigroup
+  ) where
+
+import Data.Boolean (otherwise)
+import Data.Eq ((==))
+import Data.EuclideanRing (mod, (/))
+import Data.Ord ((<=))
+import Data.Ordering (Ordering(..))
+import Data.Semigroup (class Semigroup, (<>))
+import Data.Unit (Unit, unit)
+
+-- | A `Monoid` is a `Semigroup` with a value `mempty`, which is both a
+-- | left and right unit for the associative operation `<>`:
+-- |
+-- | ```
+-- | forall x. mempty <> x = x <> mempty = x
+-- | ```
+-- |
+-- | `Monoid`s are commonly used as the result of fold operations, where
+-- | `<>` is used to combine individual results, and `mempty` gives the result
+-- | of folding an empty collection of elements.
+class Semigroup m <= Monoid m where
+  mempty :: m
+
+instance monoidUnit :: Monoid Unit where
+  mempty = unit
+
+instance monoidOrdering :: Monoid Ordering where
+  mempty = EQ
+
+instance monoidFn :: Monoid b => Monoid (a -> b) where
+  mempty _ = mempty
+
+instance monoidString :: Monoid String where
+  mempty = ""
+
+instance monoidArray :: Monoid (Array a) where
+  mempty = []
+
+-- | Append a value to itself a certain number of times. For the
+-- | `Multiplicative` type, and for a non-negative power, this is the same as
+-- | normal number exponentiation.
+-- |
+-- | If the second argument is negative this function will return `mempty`
+-- | (*unlike* normal number exponentiation). The `Monoid` constraint alone
+-- | is not enough to write a `power` function with the property that `power x
+-- | n` cancels with `power x (-n)`, i.e. `power x n <> power x (-n) = mempty`.
+-- | For that, we would additionally need the ability to invert elements, i.e.
+-- | a Group.
+power :: forall m. Monoid m => m -> Int -> m
+power x = go
+  where
+  go :: Int -> m
+  go p
+    | p <= 0 = mempty
+    | p == 1 = x
+    | p `mod` 2 == 0 = let x' = go (p / 2) in x' <> x'
+    | otherwise = let x' = go (p / 2) in x' <> x' <> x
+
+-- | Allow or "truncate" a Monoid to its `mempty` value based on a condition.
+guard :: forall m. Monoid m => Boolean -> m -> m
+guard true a = a
+guard false _ = mempty

--- a/src/Data/Monoid/Additive.purs
+++ b/src/Data/Monoid/Additive.purs
@@ -1,0 +1,44 @@
+module Data.Monoid.Additive where
+
+import Prelude
+
+import Data.Eq (class Eq1)
+import Data.Ord (class Ord1)
+
+-- | Monoid and semigroup for semirings under addition.
+-- |
+-- | ``` purescript
+-- | Additive x <> Additive y == Additive (x + y)
+-- | mempty :: Additive _ == Additive zero
+-- | ```
+newtype Additive a = Additive a
+
+derive newtype instance eqAdditive :: Eq a => Eq (Additive a)
+derive instance eq1Additive :: Eq1 Additive
+
+derive newtype instance ordAdditive :: Ord a => Ord (Additive a)
+derive instance ord1Additive :: Ord1 Additive
+
+derive newtype instance boundedAdditive :: Bounded a => Bounded (Additive a)
+
+instance showAdditive :: Show a => Show (Additive a) where
+  show (Additive a) = "(Additive " <> show a <> ")"
+
+derive instance functorAdditive :: Functor Additive
+
+instance applyAdditive :: Apply Additive where
+  apply (Additive f) (Additive x) = Additive (f x)
+
+instance applicativeAdditive :: Applicative Additive where
+  pure = Additive
+
+instance bindAdditive :: Bind Additive where
+  bind (Additive x) f = f x
+
+instance monadAdditive :: Monad Additive
+
+instance semigroupAdditive :: Semiring a => Semigroup (Additive a) where
+  append (Additive a) (Additive b) = Additive (a + b)
+
+instance monoidAdditive :: Semiring a => Monoid (Additive a) where
+  mempty = Additive zero

--- a/src/Data/Monoid/Conj.purs
+++ b/src/Data/Monoid/Conj.purs
@@ -1,0 +1,51 @@
+module Data.Monoid.Conj where
+
+import Prelude
+
+import Data.Eq (class Eq1)
+import Data.HeytingAlgebra (ff, tt)
+import Data.Ord (class Ord1)
+
+-- | Monoid and semigroup for conjuntion.
+-- |
+-- | ``` purescript
+-- | Conj x <> Conj y == Conj (x && y)
+-- | mempty :: Conj _ == Conj top
+-- | ```
+newtype Conj a = Conj a
+
+derive newtype instance eqConj :: Eq a => Eq (Conj a)
+derive instance eq1Conj :: Eq1 Conj
+
+derive newtype instance ordConj :: Ord a => Ord (Conj a)
+derive instance ord1Conj :: Ord1 Conj
+
+derive newtype instance boundedConj :: Bounded a => Bounded (Conj a)
+
+instance showConj :: (Show a) => Show (Conj a) where
+  show (Conj a) = "(Conj " <> show a <> ")"
+
+derive instance functorConj :: Functor Conj
+
+instance applyConj :: Apply Conj where
+  apply (Conj f) (Conj x) = Conj (f x)
+
+instance applicativeConj :: Applicative Conj where
+  pure = Conj
+
+instance bindConj :: Bind Conj where
+  bind (Conj x) f = f x
+
+instance monadConj :: Monad Conj
+
+instance semigroupConj :: HeytingAlgebra a => Semigroup (Conj a) where
+  append (Conj a) (Conj b) = Conj (conj a b)
+
+instance monoidConj :: HeytingAlgebra a => Monoid (Conj a) where
+  mempty = Conj tt
+
+instance semiringConj :: HeytingAlgebra a => Semiring (Conj a) where
+  zero = Conj tt
+  one = Conj ff
+  add (Conj a) (Conj b) = Conj (conj a b)
+  mul (Conj a) (Conj b) = Conj (disj a b)

--- a/src/Data/Monoid/Disj.purs
+++ b/src/Data/Monoid/Disj.purs
@@ -1,0 +1,51 @@
+module Data.Monoid.Disj where
+
+import Prelude
+
+import Data.Eq (class Eq1)
+import Data.HeytingAlgebra (ff, tt)
+import Data.Ord (class Ord1)
+
+-- | Monoid and semigroup for disjuntion.
+-- |
+-- | ``` purescript
+-- | Disj x <> Disj y == Disj (x || y)
+-- | mempty :: Disj _ == Disj bottom
+-- | ```
+newtype Disj a = Disj a
+
+derive newtype instance eqDisj :: Eq a => Eq (Disj a)
+derive instance eq1Disj :: Eq1 Disj
+
+derive newtype instance ordDisj :: Ord a => Ord (Disj a)
+derive instance ord1Disj :: Ord1 Disj
+
+derive newtype instance boundedDisj :: Bounded a => Bounded (Disj a)
+
+instance showDisj :: Show a => Show (Disj a) where
+  show (Disj a) = "(Disj " <> show a <> ")"
+
+derive instance functorDisj :: Functor Disj
+
+instance applyDisj :: Apply Disj where
+  apply (Disj f) (Disj x) = Disj (f x)
+
+instance applicativeDisj :: Applicative Disj where
+  pure = Disj
+
+instance bindDisj :: Bind Disj where
+  bind (Disj x) f = f x
+
+instance monadDisj :: Monad Disj
+
+instance semigroupDisj :: HeytingAlgebra a => Semigroup (Disj a) where
+  append (Disj a) (Disj b) = Disj (disj a b)
+
+instance monoidDisj :: HeytingAlgebra a => Monoid (Disj a) where
+  mempty = Disj ff
+
+instance semiringDisj :: HeytingAlgebra a => Semiring (Disj a) where
+  zero = Disj ff
+  one = Disj tt
+  add (Disj a) (Disj b) = Disj (disj a b)
+  mul (Disj a) (Disj b) = Disj (conj a b)

--- a/src/Data/Monoid/Dual.purs
+++ b/src/Data/Monoid/Dual.purs
@@ -1,0 +1,44 @@
+module Data.Monoid.Dual where
+
+import Prelude
+
+import Data.Eq (class Eq1)
+import Data.Ord (class Ord1)
+
+-- | The dual of a monoid.
+-- |
+-- | ``` purescript
+-- | Dual x <> Dual y == Dual (y <> x)
+-- | mempty :: Dual _ == Dual mempty
+-- | ```
+newtype Dual a = Dual a
+
+derive newtype instance eqDual :: Eq a => Eq (Dual a)
+derive instance eq1Dual :: Eq1 Dual
+
+derive newtype instance ordDual :: Ord a => Ord (Dual a)
+derive instance ord1Dual :: Ord1 Dual
+
+derive newtype instance boundedDual :: Bounded a => Bounded (Dual a)
+
+instance showDual :: Show a => Show (Dual a) where
+  show (Dual a) = "(Dual " <> show a <> ")"
+
+derive instance functorDual :: Functor Dual
+
+instance applyDual :: Apply Dual where
+  apply (Dual f) (Dual x) = Dual (f x)
+
+instance applicativeDual :: Applicative Dual where
+  pure = Dual
+
+instance bindDual :: Bind Dual where
+  bind (Dual x) f = f x
+
+instance monadDual :: Monad Dual
+
+instance semigroupDual :: Semigroup a => Semigroup (Dual a) where
+  append (Dual x) (Dual y) = Dual (y <> x)
+
+instance monoidDual :: Monoid a => Monoid (Dual a) where
+  mempty = Dual mempty

--- a/src/Data/Monoid/Endo.purs
+++ b/src/Data/Monoid/Endo.purs
@@ -1,0 +1,29 @@
+module Data.Monoid.Endo where
+
+import Prelude
+
+-- | Monoid and semigroup for category endomorphisms.
+-- |
+-- | When `c` is instantiated with `->` this composes functions of type
+-- | `a -> a`:
+-- |
+-- | ``` purescript
+-- | Endo f <> Endo g == Endo (f <<< g)
+-- | mempty :: Endo _ == Endo id
+-- | ```
+newtype Endo c a = Endo (c a a)
+
+derive newtype instance eqEndo :: Eq (c a a) => Eq (Endo c a)
+
+derive newtype instance ordEndo :: Ord (c a a) => Ord (Endo c a)
+
+derive newtype instance boundedEndo :: Bounded (c a a) => Bounded (Endo c a)
+
+instance showEndo :: Show (c a a) => Show (Endo c a) where
+  show (Endo x) = "(Endo " <> show x <> ")"
+
+instance semigroupEndo :: Semigroupoid c => Semigroup (Endo c a) where
+  append (Endo a) (Endo b) = Endo (a <<< b)
+
+instance monoidEndo :: Category c => Monoid (Endo c a) where
+  mempty = Endo id

--- a/src/Data/Monoid/Multiplicative.purs
+++ b/src/Data/Monoid/Multiplicative.purs
@@ -1,0 +1,44 @@
+module Data.Monoid.Multiplicative where
+
+import Prelude
+
+import Data.Eq (class Eq1)
+import Data.Ord (class Ord1)
+
+-- | Monoid and semigroup for semirings under multiplication.
+-- |
+-- | ``` purescript
+-- | Multiplicative x <> Multiplicative y == Multiplicative (x * y)
+-- | mempty :: Multiplicative _ == Multiplicative one
+-- | ```
+newtype Multiplicative a = Multiplicative a
+
+derive newtype instance eqMultiplicative :: Eq a => Eq (Multiplicative a)
+derive instance eq1Multiplicative :: Eq1 Multiplicative
+
+derive newtype instance ordMultiplicative :: Ord a => Ord (Multiplicative a)
+derive instance ord1Multiplicative :: Ord1 Multiplicative
+
+derive newtype instance boundedMultiplicative :: Bounded a => Bounded (Multiplicative a)
+
+instance showMultiplicative :: Show a => Show (Multiplicative a) where
+  show (Multiplicative a) = "(Multiplicative " <> show a <> ")"
+
+derive instance functorMultiplicative :: Functor Multiplicative
+
+instance applyMultiplicative :: Apply Multiplicative where
+  apply (Multiplicative f) (Multiplicative x) = Multiplicative (f x)
+
+instance applicativeMultiplicative :: Applicative Multiplicative where
+  pure = Multiplicative
+
+instance bindMultiplicative :: Bind Multiplicative where
+  bind (Multiplicative x) f = f x
+
+instance monadMultiplicative :: Monad Multiplicative
+
+instance semigroupMultiplicative :: Semiring a => Semigroup (Multiplicative a) where
+  append (Multiplicative a) (Multiplicative b) = Multiplicative (a * b)
+
+instance monoidMultiplicative :: Semiring a => Monoid (Multiplicative a) where
+  mempty = Multiplicative one

--- a/src/Data/Semigroup/First.purs
+++ b/src/Data/Semigroup/First.purs
@@ -1,0 +1,40 @@
+module Data.Semigroup.First where
+
+import Prelude
+
+import Data.Eq (class Eq1)
+import Data.Ord (class Ord1)
+
+-- | Semigroup where `append` always takes the first option.
+-- |
+-- | ``` purescript
+-- | First x <> First y == First x
+-- | ```
+newtype First a = First a
+
+derive newtype instance eqFirst :: Eq a => Eq (First a)
+derive instance eq1First :: Eq1 First
+
+derive newtype instance ordFirst :: Ord a => Ord (First a)
+derive instance ord1First :: Ord1 First
+
+derive newtype instance boundedFirst :: Bounded a => Bounded (First a)
+
+instance showFirst :: Show a => Show (First a) where
+  show (First a) = "(First " <> show a <> ")"
+
+derive instance functorFirst :: Functor First
+
+instance applyFirst :: Apply First where
+  apply (First f) (First x) = First (f x)
+
+instance applicativeFirst :: Applicative First where
+  pure = First
+
+instance bindFirst :: Bind First where
+  bind (First x) f = f x
+
+instance monadFirst :: Monad First
+
+instance semigroupFirst :: Semigroup (First a) where
+  append x _ = x

--- a/src/Data/Semigroup/Last.purs
+++ b/src/Data/Semigroup/Last.purs
@@ -1,0 +1,40 @@
+module Data.Semigroup.Last where
+
+import Prelude
+
+import Data.Eq (class Eq1)
+import Data.Ord (class Ord1)
+
+-- | Semigroup where `append` always takes the second option.
+-- |
+-- | ``` purescript
+-- | Last x <> Last y == Last x
+-- | ```
+newtype Last a = Last a
+
+derive newtype instance eqLast :: Eq a => Eq (Last a)
+derive instance eq1Last :: Eq1 Last
+
+derive newtype instance ordLast :: Ord a => Ord (Last a)
+derive instance ord1Last :: Ord1 Last
+
+derive newtype instance boundedLast :: Bounded a => Bounded (Last a)
+
+instance showLast :: Show a => Show (Last a) where
+  show (Last a) = "(Last " <> show a <> ")"
+
+derive instance functorLast :: Functor Last
+
+instance applyLast :: Apply Last where
+  apply (Last f) (Last x) = Last (f x)
+
+instance applicativeLast :: Applicative Last where
+  pure = Last
+
+instance bindLast :: Bind Last where
+  bind (Last x) f = f x
+
+instance monadLast :: Monad Last
+
+instance semigroupLast :: Semigroup (Last a) where
+  append _ x = x

--- a/src/Data/Semigroup/Max.purs
+++ b/src/Data/Semigroup/Max.purs
@@ -1,0 +1,40 @@
+module Data.Semigroup.Max where
+
+import Prelude
+
+import Data.Eq (class Eq1)
+import Data.Ord (class Ord1)
+
+-- | Semigroup where `append` always takes the greater value.
+-- |
+-- | ``` purescript
+-- | Max x <> Max y == Max (if x >= y then x else y)
+-- | ```
+newtype Max a = Max a
+
+derive newtype instance eqMax :: Eq a => Eq (Max a)
+derive instance eq1Max :: Eq1 Max
+
+derive newtype instance ordMax :: Ord a => Ord (Max a)
+derive instance ord1Max :: Ord1 Max
+
+derive newtype instance boundedMax :: Bounded a => Bounded (Max a)
+
+instance showMax :: Show a => Show (Max a) where
+  show (Max a) = "(Max " <> show a <> ")"
+
+derive instance functorMax :: Functor Max
+
+instance applyMax :: Apply Max where
+  apply (Max f) (Max x) = Max (f x)
+
+instance applicativeMax :: Applicative Max where
+  pure = Max
+
+instance bindMax :: Bind Max where
+  bind (Max x) f = f x
+
+instance monadMax :: Monad Max
+
+instance semigroupMax :: Ord a => Semigroup (Max a) where
+  append (Max x) (Max y) = Max (max x y)

--- a/src/Data/Semigroup/Min.purs
+++ b/src/Data/Semigroup/Min.purs
@@ -1,0 +1,40 @@
+module Data.Semigroup.Min where
+
+import Prelude
+
+import Data.Eq (class Eq1)
+import Data.Ord (class Ord1)
+
+-- | Semigroup where `append` always takes the lesser value.
+-- |
+-- | ``` purescript
+-- | Min x <> Min y == Min (if x <= y then x else y)
+-- | ```
+newtype Min a = Min a
+
+derive newtype instance eqMin :: Eq a => Eq (Min a)
+derive instance eq1Min :: Eq1 Min
+
+derive newtype instance ordMin :: Ord a => Ord (Min a)
+derive instance ord1Min :: Ord1 Min
+
+derive newtype instance boundedMin :: Bounded a => Bounded (Min a)
+
+instance showMin :: Show a => Show (Min a) where
+  show (Min a) = "(Min " <> show a <> ")"
+
+derive instance functorMin :: Functor Min
+
+instance applyMin :: Apply Min where
+  apply (Min f) (Min x) = Min (f x)
+
+instance applicativeMin :: Applicative Min where
+  pure = Min
+
+instance bindMin :: Bind Min where
+  bind (Min x) f = f x
+
+instance monadMin :: Monad Min
+
+instance semigroupMin :: Ord a => Semigroup (Min a) where
+  append (Min x) (Min y) = Min (min x y)

--- a/src/Prelude.purs
+++ b/src/Prelude.purs
@@ -16,6 +16,7 @@ module Prelude
   , module Data.Function
   , module Data.Functor
   , module Data.HeytingAlgebra
+  , module Data.Monoid
   , module Data.NaturalTransformation
   , module Data.Ord
   , module Data.Ordering
@@ -45,6 +46,7 @@ import Data.Field (class Field)
 import Data.Function (const, flip, ($), (#))
 import Data.Functor (class Functor, flap, map, void, ($>), (<#>), (<$), (<$>), (<@>))
 import Data.HeytingAlgebra (class HeytingAlgebra, conj, disj, not, (&&), (||))
+import Data.Monoid (class Monoid, mempty)
 import Data.NaturalTransformation (type (~>))
 import Data.Ord (class Ord, compare, (<), (<=), (>), (>=), comparing, min, max, clamp, between)
 import Data.Ordering (Ordering(..))


### PR DESCRIPTION
Resolves #163, resolves #157

I generalized the `Endo` monoid to any category while I was at it - I know we have `Join` that does the same thing, but we can probably just do away with that instead, since that's tucked away in `-profunctor`.

This will fail to build just now as it uses `Eq1` and `Ord1` deriving that is only present in 0.12.