### PR TITLE
Optimization for Eq Array

### DIFF
--- a/src/Data/Eq.js
+++ b/src/Data/Eq.js
@@ -9,6 +9,7 @@ exports.refEq = function (r1) {
 exports.eqArrayImpl = function (f) {
   return function (xs) {
     return function (ys) {
+      if (xs === ys) return true;
       if (xs.length !== ys.length) return false;
       for (var i = 0; i < xs.length; i++) {
         if (!f(xs[i])(ys[i])) return false;


### PR DESCRIPTION
Running Eq on large nested data structures can be expensive (think rose trees with 10^5 items), so checking for reference equality before traversing the array can result in some significant gains.