### PR TITLE
Fix CI for preparation for 0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js: stable
 env:
   - PATH=$HOME/purescript:$PATH
 install:
-  - TAG=0.14.0-rc2
+  - TAG=v0.14.0-rc2
   # - TAG=$(basename $(curl --location --silent --output /dev/null -w %{url_effective} https://github.com/purescript/purescript/releases/latest))
   - curl --location --output $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$TAG/linux64.tar.gz
   - tar -xvf $HOME/purescript.tar.gz -C $HOME/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ node_js: stable
 env:
   - PATH=$HOME/purescript:$PATH
 install:
-  - TAG=$(basename $(curl --location --silent --output /dev/null -w %{url_effective} https://github.com/purescript/purescript/releases/latest))
+  - TAG=0.14.0-rc2
+  # - TAG=$(basename $(curl --location --silent --output /dev/null -w %{url_effective} https://github.com/purescript/purescript/releases/latest))
   - curl --location --output $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$TAG/linux64.tar.gz
   - tar -xvf $HOME/purescript.tar.gz -C $HOME/
   - chmod a+x $HOME/purescript


### PR DESCRIPTION
I'd like to keep CI working while we're preparing the core libraries for the upcoming 0.14.0 release. This seems like a reasonable way of doing it for now. We'll need to go back through the core libraries to tag proper versions again later anyway, so we can revert this change then.

As an alternative I considered making a `v0.14.0-rc2` release on npm, but unfortunately the npm installer isn't happy with that:

```
$ node index.js --purs-ver=0.14.0-rc2
✖ Check if a prebuilt 0.14.0-rc2 binary is provided for linux
  Error: Expected `version` option to be a string of PureScript version, for example '0.12.5', but go
t an invalid version '0.14.0-rc2'.
```

This would probably be relatively easy to fix, but a one-line change in .travis.yml seems easier.