### PR TITLE
Fix warnings and doc-comments for 0.14

### DIFF
--- a/src/Control/Category.purs
+++ b/src/Control/Category.purs
@@ -13,6 +13,7 @@ import Control.Semigroupoid (class Semigroupoid, compose, (<<<), (>>>))
 -- | `Semigroupoid` law:
 -- |
 -- | - Identity: `identity <<< p = p <<< identity = p`
+class Category :: forall k. (k -> k -> Type) -> Constraint
 class Semigroupoid a <= Category a where
   identity :: forall t. a t t
 

--- a/src/Control/Semigroupoid.purs
+++ b/src/Control/Semigroupoid.purs
@@ -9,6 +9,7 @@ module Control.Semigroupoid where
 -- |
 -- | One example of a `Semigroupoid` is the function type constructor `(->)`,
 -- | with `(<<<)` defined as function composition.
+class Semigroupoid :: forall k. (k -> k -> Type) -> Constraint
 class Semigroupoid a where
   compose :: forall b c d. a c d -> a b c -> a b d
 

--- a/src/Data/Monoid/Endo.purs
+++ b/src/Data/Monoid/Endo.purs
@@ -11,6 +11,7 @@ import Prelude
 -- | Endo f <> Endo g == Endo (f <<< g)
 -- | (mempty :: Endo _) == Endo identity
 -- | ```
+newtype Endo :: forall k. (k -> k -> Type) -> k -> Type
 newtype Endo c a = Endo (c a a)
 
 derive newtype instance eqEndo :: Eq (c a a) => Eq (Endo c a)

--- a/src/Data/NaturalTransformation.purs
+++ b/src/Data/NaturalTransformation.purs
@@ -14,6 +14,7 @@ module Data.NaturalTransformation where
 -- | `f` and `g` should be functors, but the `Functor` constraint is not
 -- | enforced here; that the types are of kind `Type -> Type` is enough for our
 -- | purposes.
+type NaturalTransformation :: forall k. (k -> Type) -> (k -> Type) -> Type
 type NaturalTransformation f g = forall a. f a -> g a
 
 infixr 4 type NaturalTransformation as ~>

--- a/src/Data/NaturalTransformation.purs
+++ b/src/Data/NaturalTransformation.purs
@@ -3,8 +3,8 @@ module Data.NaturalTransformation where
 -- | A type for natural transformations.
 -- |
 -- | A natural transformation is a mapping between type constructors of kind
--- | `Type -> Type` where the mapping operation has no ability to manipulate the
--- | inner values.
+-- | `k -> Type`, for any kind `k`, where the mapping operation has no ability
+-- | to manipulate the inner values.
 -- |
 -- | An example of this is the `fromFoldable` function provided in
 -- | `purescript-lists`, where some foldable structure containing values of
@@ -12,7 +12,7 @@ module Data.NaturalTransformation where
 -- |
 -- | The definition of a natural transformation in category theory states that
 -- | `f` and `g` should be functors, but the `Functor` constraint is not
--- | enforced here; that the types are of kind `Type -> Type` is enough for our
+-- | enforced here; that the types are of kind `k -> Type` is enough for our
 -- | purposes.
 type NaturalTransformation :: forall k. (k -> Type) -> (k -> Type) -> Type
 type NaturalTransformation f g = forall a. f a -> g a

--- a/src/Type/Data/Row.purs
+++ b/src/Type/Data/Row.purs
@@ -1,6 +1,6 @@
 module Type.Data.Row where
 
--- | A proxy data type whose type parameter is a type of kind `# Type` (a row
+-- | A proxy data type whose type parameter is a type of kind `Row Type` (a row
 -- | of types).
 -- |
 -- | Commonly used for specialising a function with a quantified type.

--- a/src/Type/Data/RowList.purs
+++ b/src/Type/Data/RowList.purs
@@ -1,6 +1,6 @@
 module Type.Data.RowList where
 
-import Prim.RowList (kind RowList)
+import Prim.RowList (RowList)
 
 -- | A proxy to carry information about a rowlist.
 data RLProxy (rowlist :: RowList Type)


### PR DESCRIPTION
Like #226, except that it's based on the previous PRs #209 and #211 which mysteriously got closed - apparently by me but I don't remember doing that - and GitHub won't let me reopen them either. I'd like to merge this one instead of #226 since it preserves @Thimoteus's authorship as well as the doc-comment update in NaturalTransformation.