### PR TITLE
Fix warnings revealed by v0.14.1 PS release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Fix warnings revealed by `v0.14.1` PS release (#262)
 
 ## [v5.0.0](https://github.com/purescript/purescript-prelude/releases/tag/v5.0.0) - 2021-02-26
 

--- a/src/Data/Ord/Generic.purs
+++ b/src/Data/Ord/Generic.purs
@@ -19,8 +19,8 @@ instance genericOrdNoArguments :: GenericOrd NoArguments where
 instance genericOrdSum :: (GenericOrd a, GenericOrd b) => GenericOrd (Sum a b) where
   genericCompare' (Inl a1) (Inl a2) = genericCompare' a1 a2
   genericCompare' (Inr b1) (Inr b2) = genericCompare' b1 b2
-  genericCompare' (Inl b1) (Inr b2) = LT
-  genericCompare' (Inr b1) (Inl b2) = GT
+  genericCompare' (Inl _) (Inr _) = LT
+  genericCompare' (Inr _) (Inl _) = GT
 
 instance genericOrdProduct :: (GenericOrd a, GenericOrd b) => GenericOrd (Product a b) where
   genericCompare' (Product a1 b1) (Product a2 b2) =


### PR DESCRIPTION
**Description of the change**

The `v0.14.1` PS release now reports warnings on more things. CI will fail due to these new warnings. This PR fixes those warnings.

Backlinking to purescript/purescript#4071

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
