### PR TITLE
Make `Data.Function#apply` point-free

### DIFF
--- a/src/Data/Function.purs
+++ b/src/Data/Function.purs
@@ -39,7 +39,7 @@ const a _ = a
 -- | `($)` which allows parentheses to be omitted in some cases, or as a
 -- | natural way to apply a chain of composed functions to a value.
 apply :: forall a b. (a -> b) -> a -> b
-apply f x = f x
+apply f = f
 
 -- | Applies a function to an argument: the reverse of `(#)`.
 -- |


### PR DESCRIPTION
**Description of the change**

Just made `apply` point-free.

I know this sounds like a weird change to make a full PR for (and it is), but it's just been nagging my mind since forever, so I thought I'd just go ahead and do it. Feel free to reject this PR too; that works for me, as the nagging has already stopped.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)") (does this change deserve being in the changelog?)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
