### PR TITLE
Change Unit representaiton from `{}` to `undefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Changed `unit`'s FFI representation from `{}` to `undefined` (#267 by @JordanMartinez)
 
 ## [v5.0.1](https://github.com/purescript/purescript-prelude/releases/tag/v5.0.1) - 2021-05-11
 

--- a/src/Data/Unit.js
+++ b/src/Data/Unit.js
@@ -1,3 +1,3 @@
 "use strict";
 
-exports.unit = {};
+exports.unit = undefined;


### PR DESCRIPTION
**Description of the change**

Fixes #266. Did we want to change the wording for the docs at all? Perhaps just say "don't return a value at all" instead?

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
