### PR TITLE
Add `mapRecord` to simulate Functor Record instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `mapRecord` to simulate a `Functor` instance for `Record` (#268 by @JordanMartinez)
+
+  A `Record`'s kind signature (`Row Type -> Type`) does not satisfy the kind signature requirements
+  of `Functor`, so we can't define a `Functor` type class instance for `Record`, even if it
+  otherwise satisfies it. Although this could be done via a Newtype, it involves
+  a lot more type-level machinery to make it work.
 
 Bugfixes:
 

--- a/src/Data/Functor.purs
+++ b/src/Data/Functor.purs
@@ -5,10 +5,16 @@ module Data.Functor
   , voidRight, (<$)
   , voidLeft, ($>)
   , flap, (<@>)
+  , mapRecord
+  , class FunctorRecord, mapRecordImpl
   ) where
 
 import Data.Function (const, compose)
+import Data.Symbol (class IsSymbol, reflectSymbol)
 import Data.Unit (Unit, unit)
+import Prim.Row as Row
+import Prim.RowList as RL
+import Record.Unsafe (unsafeSet, unsafeGet)
 import Type.Proxy (Proxy(..))
 
 -- | A `Functor` is a type constructor which supports a mapping operation
@@ -22,6 +28,8 @@ import Type.Proxy (Proxy(..))
 -- |
 -- | - Identity: `map identity = identity`
 -- | - Composition: `map (f <<< g) = map f <<< map g`
+-- |
+-- | For calling `map` on each label of a record, see `mapRecord`.
 class Functor f where
   map :: forall a b. (a -> b) -> f a -> f b
 
@@ -98,3 +106,42 @@ flap :: forall f a b. Functor f => f (a -> b) -> a -> f b
 flap ff x = map (\f -> f x) ff
 
 infixl 4 flap as <@>
+
+-- | Same as `Functor`'s `map` but works on records where
+-- | each label is associated with a `Functor` type that stores the same `a` type:
+-- |
+-- | - Valid: `{ a :: Array Int, b :: Array Int }`
+-- | - Valid, because the `a` type is the same: `{ x :: Maybe Int, y :: Array Int }`
+-- | - Invalid, because the `a` type changes: `{ x :: Array Int, y :: Array String }`
+-- |
+-- | ```purescript
+-- | mapRecord (_ + 1) { x: [ 1 ], y: [ 2 ] } == { x: [ 2 ], y: [ 3 ] }
+-- | ```
+mapRecord
+  :: forall a b rowList rows mappedRows
+   . RL.RowToList rows rowList
+  => FunctorRecord rowList a b rows mappedRows
+  => (a -> b)
+  -> { | rows }
+  -> { | mappedRows }
+mapRecord func rec = mapRecordImpl (Proxy :: Proxy rowList) func rec
+
+class FunctorRecord :: (RL.RowList Type) -> Type -> Type -> Row Type -> Row Type -> Constraint
+class FunctorRecord rowlist a b row subrow | rowlist a b -> row subrow where
+  mapRecordImpl :: Proxy rowlist -> (a -> b) -> { | row } -> { | subrow }
+
+instance functorRecordNil :: FunctorRecord RL.Nil a b row () where
+  mapRecordImpl _ _ _ = {}
+
+instance functorRecordCons ::
+  ( IsSymbol key
+  , Row.Cons key (f b) subrowTail subrow
+  , FunctorRecord rowlistTail a b row subrowTail
+  , Functor f
+  ) => FunctorRecord (RL.Cons key (f a) rowlistTail) a b row subrow where
+  mapRecordImpl _ func rec = insert (map func (get rec)) tail
+    where
+    key = reflectSymbol (Proxy :: Proxy key)
+    get = unsafeGet key
+    insert = unsafeSet key :: f b -> { | subrowTail } -> { | subrow }
+    tail = mapRecordImpl (Proxy :: Proxy rowlistTail) func rec

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -1,6 +1,8 @@
 module Test.Main where
 
 import Prelude
+
+import Data.Functor (mapRecord)
 import Data.HeytingAlgebra (ff, tt, implies)
 import Data.Ord (abs)
 import Test.Data.Generic.Rep (testGenericRep)
@@ -151,3 +153,15 @@ testRecordInstances = do
   assert "Record top" $
     (top :: { a :: Boolean }).a
     == top
+
+  assert "mapRecord" $
+    mapRecord (_ + 1) { a: [ 1 ], b: [ 2 ] }
+    == { a: [ 2 ], b: [ 3 ] }
+
+  assert "mapRecord" $
+    mapRecord (_ + 1) { a: [ 1 ], b: Box 2 }
+    == { a: [ 2 ], b: Box 3 }
+
+data Box a = Box a
+derive instance (Eq a) => Eq (Box a)
+derive instance Functor Box


### PR DESCRIPTION
**Description of the change**

See https://github.com/natefaubion/purescript-tidy-codegen/issues/3#issuecomment-917422266 and its surrounding context.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
