### PR TITLE
Extend comment to Ord noting that Number is not fully law abiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Other improvements:
 - Changed `unit`'s FFI representation from `{}` to `undefined` (#267 by @JordanMartinez)
 - Added clearer docs for Prelude module (#270 by @JordanMartinez)
 - Clarify docs for `flip` (#271 by @JordanMartinez)
+- Add comment that `Number` is not a fully law abiding instance of `Ord` (#277 by @JamieBallingall)
 
 ## [v5.0.1](https://github.com/purescript/purescript-prelude/releases/tag/v5.0.1) - 2021-05-11
 

--- a/src/Data/Ord.purs
+++ b/src/Data/Ord.purs
@@ -34,6 +34,9 @@ import Type.Proxy (Proxy(..), Proxy2, Proxy3)
 -- | - Reflexivity: `a <= a`
 -- | - Antisymmetry: if `a <= b` and `b <= a` then `a = b`
 -- | - Transitivity: if `a <= b` and `b <= c` then `a <= c`
+-- |
+-- | **Note:** The `Number` type is not an entirely law abiding member of this
+-- | class due to the presence of `NaN`, since `NaN <= NaN` evaluates to `false`
 class Eq a <= Ord a where
   compare :: a -> a -> Ordering
 


### PR DESCRIPTION
Adds a note in the comment to the `Ord` typeclass indicating that `Number` does not have a fully law abiding instance of `Ord`. This is because `NaN <= NaN` evaluates to `false`.

This PR closes #276.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [X] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
