### PR TITLE
Format test code

### DIFF
--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -8,67 +8,67 @@ import Test.Utils (AlmostEff, assert)
 
 main :: AlmostEff
 main = do
-    testNumberShow show
-    testOrderings
-    testOrdUtils
-    testIntDivMod
-    testIntDegree
-    testRecordInstances
-    testGenericRep
+  testNumberShow show
+  testOrderings
+  testOrdUtils
+  testIntDivMod
+  testIntDegree
+  testRecordInstances
+  testGenericRep
 
 foreign import testNumberShow :: (Number -> String) -> AlmostEff
 
 testOrd :: forall a. Ord a => Show a => a -> a -> Ordering -> AlmostEff
 testOrd x y ord =
-    assert
-        ("(compare " <> show x <> " " <> show y <> " ) is not equal to " <> show ord)
-        $ (compare x y) == ord
-
-nan :: Number
-nan = 0.0/0.0
-
-plusInfinity :: Number
-plusInfinity = 1.0/0.0
-
-minusInfinity :: Number
-minusInfinity = -1.0/0.0
+  assert
+    ("(compare " <> show x <> " " <> show y <> " ) is not equal to " <> show ord)
+    $ (compare x y) == ord
 
 testOrderings :: AlmostEff
 testOrderings = do
-    assert "NaN shouldn't be equal to itself" $ nan /= nan
-    assert "NaN shouldn't be equal to itself" $ (compare nan nan) /= EQ
-    testOrd 1.0    2.0 LT
-    testOrd 2.0    1.0 GT
-    testOrd 1.0    (-2.0) GT
-    testOrd (-2.0) 1.0 LT
-    testOrd minusInfinity plusInfinity LT
-    testOrd minusInfinity 0.0 LT
-    testOrd plusInfinity  0.0 GT
-    testOrd plusInfinity  minusInfinity GT
-    testOrd 1.0 nan GT
-    testOrd nan 1.0 GT
-    testOrd nan plusInfinity GT
-    testOrd plusInfinity nan GT
-    assert "1 > NaN should be false" $ (1.0 > nan) == false
-    assert "1 < NaN should be false" $ (1.0 < nan) == false
-    assert "NaN > 1 should be false" $ (nan > 1.0) == false
-    assert "NaN < 1 should be false" $ (nan < 1.0) == false
-    assert "NaN == 1 should be false" $ nan /= 1.0
-    testOrd (1 / 0) 0 EQ
-    testOrd (mod 1 0) 0 EQ
-    testOrd 'a' 'b' LT
-    testOrd 'b' 'A' GT
-    testOrd "10" "0" GT
-    testOrd "10" "2" LT
-    testOrd true  true EQ
-    testOrd false false EQ
-    testOrd false true LT
-    testOrd true  false GT
-    testOrd ([] :: Array Int) [] EQ
-    testOrd [1, 0]  [1] GT
-    testOrd [1]     [1, 0] LT
-    testOrd [1, 1]  [1, 0] GT
-    testOrd [1, -1] [1, 0] LT
+  assert "NaN shouldn't be equal to itself" $ nan /= nan
+  assert "NaN shouldn't be equal to itself" $ (compare nan nan) /= EQ
+  testOrd 1.0    2.0 LT
+  testOrd 2.0    1.0 GT
+  testOrd 1.0    (-2.0) GT
+  testOrd (-2.0) 1.0 LT
+  testOrd minusInfinity plusInfinity LT
+  testOrd minusInfinity 0.0 LT
+  testOrd plusInfinity  0.0 GT
+  testOrd plusInfinity  minusInfinity GT
+  testOrd 1.0 nan GT
+  testOrd nan 1.0 GT
+  testOrd nan plusInfinity GT
+  testOrd plusInfinity nan GT
+  assert "1 > NaN should be false" $ (1.0 > nan) == false
+  assert "1 < NaN should be false" $ (1.0 < nan) == false
+  assert "NaN > 1 should be false" $ (nan > 1.0) == false
+  assert "NaN < 1 should be false" $ (nan < 1.0) == false
+  assert "NaN == 1 should be false" $ nan /= 1.0
+  testOrd (1 / 0) 0 EQ
+  testOrd (mod 1 0) 0 EQ
+  testOrd 'a' 'b' LT
+  testOrd 'b' 'A' GT
+  testOrd "10" "0" GT
+  testOrd "10" "2" LT
+  testOrd true  true EQ
+  testOrd false false EQ
+  testOrd false true LT
+  testOrd true  false GT
+  testOrd ([] :: Array Int) [] EQ
+  testOrd [1, 0]  [1] GT
+  testOrd [1]     [1, 0] LT
+  testOrd [1, 1]  [1, 0] GT
+  testOrd [1, -1] [1, 0] LT
+  where
+    nan :: Number
+    nan = 0.0/0.0
+
+    plusInfinity :: Number
+    plusInfinity = 1.0/0.0
+
+    minusInfinity :: Number
+    minusInfinity = -1.0/0.0
 
 testOrdUtils :: AlmostEff
 testOrdUtils = do
@@ -107,11 +107,11 @@ testIntDivMod = do
 
 testIntDegree :: AlmostEff
 testIntDegree = do
-    let bot = bottom :: Int
-    assert "degree returns absolute integers" $ degree (-4) == 4
-    assert "degree returns absolute integers" $ degree 4 == 4
-    assert "degree returns absolute integers" $ degree bot >= 0
-    assert "degree does not return out-of-bounds integers" $ degree bot <= top
+  let bot = bottom :: Int
+  assert "degree returns absolute integers" $ degree (-4) == 4
+  assert "degree returns absolute integers" $ degree 4 == 4
+  assert "degree returns absolute integers" $ degree bot >= 0
+  assert "degree does not return out-of-bounds integers" $ degree bot <= top
 
 testRecordInstances :: AlmostEff
 testRecordInstances = do


### PR DESCRIPTION
**Description of the change**

Fixed a formatting in Test/Main.purs.
Indentation was a mix of 2 and 4, now unified to 2. Some of the top-level definitions are now under the where clause.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
