### PR TITLE
Replace polymorphic proxy workaround with monomorphic Proxy type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 - Migrated FFI to ES Modules (#287 by @kl0tl and @JordanMartinez)
+- Replace `forall proxy. proxy k` workaound with `Proxy k` (#281 by @JordanMartinez)
+- Drop all kind-specific Proxy types (e.g. `Proxy2`, `Proxy3`) (#281 by @JordanMartinez)
 
 New features:
 

--- a/src/Control/Bind.purs
+++ b/src/Control/Bind.purs
@@ -1,10 +1,16 @@
 module Control.Bind
-  ( class Bind, bind, (>>=)
-  , bindFlipped, (=<<)
-  , class Discard, discard
+  ( class Bind
+  , bind
+  , (>>=)
+  , bindFlipped
+  , (=<<)
+  , class Discard
+  , discard
   , join
-  , composeKleisli, (>=>)
-  , composeKleisliFlipped, (<=<)
+  , composeKleisli
+  , (>=>)
+  , composeKleisliFlipped
+  , (<=<)
   , ifM
   , module Data.Functor
   , module Control.Apply
@@ -18,7 +24,7 @@ import Control.Category (identity)
 import Data.Function (flip)
 import Data.Functor (class Functor, map, void, ($>), (<#>), (<$), (<$>))
 import Data.Unit (Unit)
-import Type.Proxy (Proxy(..), Proxy2, Proxy3)
+import Type.Proxy (Proxy(..))
 
 -- | The `Bind` type class extends the [`Apply`](#apply) type class with a
 -- | "bind" operation `(>>=)` which composes computations in sequence, using
@@ -105,12 +111,6 @@ instance discardUnit :: Discard Unit where
   discard = bind
 
 instance discardProxy :: Discard (Proxy a) where
-  discard = bind
-
-instance discardProxy2 :: Discard (Proxy2 a) where
-  discard = bind
-
-instance discardProxy3 :: Discard (Proxy3 a) where
   discard = bind
 
 -- | Collapse two applications of a monadic type constructor into one.

--- a/src/Data/BooleanAlgebra.purs
+++ b/src/Data/BooleanAlgebra.purs
@@ -9,7 +9,7 @@ import Data.Symbol (class IsSymbol)
 import Data.Unit (Unit)
 import Prim.Row as Row
 import Prim.RowList as RL
-import Type.Proxy (Proxy, Proxy2, Proxy3)
+import Type.Proxy (Proxy)
 
 -- | The `BooleanAlgebra` type class represents types that behave like boolean
 -- | values.
@@ -26,8 +26,6 @@ instance booleanAlgebraUnit :: BooleanAlgebra Unit
 instance booleanAlgebraFn :: BooleanAlgebra b => BooleanAlgebra (a -> b)
 instance booleanAlgebraRecord :: (RL.RowToList row list, BooleanAlgebraRecord list row row) => BooleanAlgebra (Record row)
 instance booleanAlgebraProxy :: BooleanAlgebra (Proxy a)
-instance booleanAlgebraProxy2 :: BooleanAlgebra (Proxy2 a)
-instance booleanAlgebraProxy3 :: BooleanAlgebra (Proxy3 a)
 
 -- | A class for records where all fields have `BooleanAlgebra` instances, used
 -- | to implement the `BooleanAlgebra` instance for records.
@@ -36,10 +34,10 @@ class HeytingAlgebraRecord rowlist row subrow <= BooleanAlgebraRecord rowlist ro
 
 instance booleanAlgebraRecordNil :: BooleanAlgebraRecord RL.Nil row ()
 
-instance booleanAlgebraRecordCons
-    :: ( IsSymbol key
-       , Row.Cons key focus subrowTail subrow
-       , BooleanAlgebraRecord rowlistTail row subrowTail
-       , BooleanAlgebra focus
-       )
-    => BooleanAlgebraRecord (RL.Cons key focus rowlistTail) row subrow
+instance booleanAlgebraRecordCons ::
+  ( IsSymbol key
+  , Row.Cons key focus subrowTail subrow
+  , BooleanAlgebraRecord rowlistTail row subrowTail
+  , BooleanAlgebra focus
+  ) =>
+  BooleanAlgebraRecord (RL.Cons key focus rowlistTail) row subrow

--- a/src/Data/Bounded.purs
+++ b/src/Data/Bounded.purs
@@ -3,7 +3,9 @@ module Data.Bounded
   , bottom
   , top
   , module Data.Ord
-  , class BoundedRecord, bottomRecord, topRecord
+  , class BoundedRecord
+  , bottomRecord
+  , topRecord
   ) where
 
 import Data.Ord (class Ord, class OrdRecord, Ordering(..), compare, (<), (<=), (>), (>=))
@@ -75,39 +77,37 @@ instance boundedProxy3 :: Bounded (Proxy3 a) where
 
 class BoundedRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class OrdRecord rowlist row <= BoundedRecord rowlist row subrow | rowlist -> subrow where
-  topRecord :: forall rlproxy rproxy. rlproxy rowlist -> rproxy row -> Record subrow
-  bottomRecord :: forall rlproxy rproxy. rlproxy rowlist -> rproxy row -> Record subrow
+  topRecord :: Proxy rowlist -> Proxy row -> Record subrow
+  bottomRecord :: Proxy rowlist -> Proxy row -> Record subrow
 
 instance boundedRecordNil :: BoundedRecord RL.Nil row () where
   topRecord _ _ = {}
   bottomRecord _ _ = {}
 
-instance boundedRecordCons
-    :: ( IsSymbol key
-       , Bounded focus
-       , Row.Cons key focus rowTail row
-       , Row.Cons key focus subrowTail subrow
-       , BoundedRecord rowlistTail row subrowTail
-       )
-    => BoundedRecord (RL.Cons key focus rowlistTail) row subrow where
-  topRecord _ rowProxy
-    = insert top tail
+instance boundedRecordCons ::
+  ( IsSymbol key
+  , Bounded focus
+  , Row.Cons key focus rowTail row
+  , Row.Cons key focus subrowTail subrow
+  , BoundedRecord rowlistTail row subrowTail
+  ) =>
+  BoundedRecord (RL.Cons key focus rowlistTail) row subrow where
+  topRecord _ rowProxy = insert top tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-      tail = topRecord (Proxy :: Proxy rowlistTail) rowProxy
+    key = reflectSymbol (Proxy :: Proxy key)
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    tail = topRecord (Proxy :: Proxy rowlistTail) rowProxy
 
-  bottomRecord _ rowProxy
-    = insert bottom tail
+  bottomRecord _ rowProxy = insert bottom tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-      tail = bottomRecord (Proxy :: Proxy rowlistTail) rowProxy
+    key = reflectSymbol (Proxy :: Proxy key)
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    tail = bottomRecord (Proxy :: Proxy rowlistTail) rowProxy
 
-instance boundedRecord
-    :: ( RL.RowToList row list
-       , BoundedRecord list row row
-       )
-    => Bounded (Record row) where
+instance boundedRecord ::
+  ( RL.RowToList row list
+  , BoundedRecord list row row
+  ) =>
+  Bounded (Record row) where
   top = topRecord (Proxy :: Proxy list) (Proxy :: Proxy row)
   bottom = bottomRecord (Proxy :: Proxy list) (Proxy :: Proxy row)

--- a/src/Data/Bounded.purs
+++ b/src/Data/Bounded.purs
@@ -14,7 +14,7 @@ import Data.Unit (Unit, unit)
 import Prim.Row as Row
 import Prim.RowList as RL
 import Record.Unsafe (unsafeSet)
-import Type.Proxy (Proxy(..), Proxy2(..), Proxy3(..))
+import Type.Proxy (Proxy(..))
 
 -- | The `Bounded` type class represents totally ordered types that have an
 -- | upper and lower boundary.
@@ -66,14 +66,6 @@ instance boundedNumber :: Bounded Number where
 instance boundedProxy :: Bounded (Proxy a) where
   bottom = Proxy
   top = Proxy
-
-instance boundedProxy2 :: Bounded (Proxy2 a) where
-  bottom = Proxy2
-  top = Proxy2
-
-instance boundedProxy3 :: Bounded (Proxy3 a) where
-  bottom = Proxy3
-  top = Proxy3
 
 class BoundedRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class OrdRecord rowlist row <= BoundedRecord rowlist row subrow | rowlist -> subrow where

--- a/src/Data/CommutativeRing.purs
+++ b/src/Data/CommutativeRing.purs
@@ -11,7 +11,7 @@ import Data.Symbol (class IsSymbol)
 import Data.Unit (Unit)
 import Prim.Row as Row
 import Prim.RowList as RL
-import Type.Proxy (Proxy, Proxy2, Proxy3)
+import Type.Proxy (Proxy)
 
 -- | The `CommutativeRing` class is for rings where multiplication is
 -- | commutative.
@@ -28,8 +28,6 @@ instance commutativeRingUnit :: CommutativeRing Unit
 instance commutativeRingFn :: CommutativeRing b => CommutativeRing (a -> b)
 instance commutativeRingRecord :: (RL.RowToList row list, CommutativeRingRecord list row row) => CommutativeRing (Record row)
 instance commutativeRingProxy :: CommutativeRing (Proxy a)
-instance commutativeRingProxy2 :: CommutativeRing (Proxy2 a)
-instance commutativeRingProxy3 :: CommutativeRing (Proxy3 a)
 
 -- | A class for records where all fields have `CommutativeRing` instances, used
 -- | to implement the `CommutativeRing` instance for records.
@@ -37,10 +35,10 @@ class RingRecord rowlist row subrow <= CommutativeRingRecord rowlist row subrow 
 
 instance commutativeRingRecordNil :: CommutativeRingRecord RL.Nil row ()
 
-instance commutativeRingRecordCons
-    :: ( IsSymbol key
-       , Row.Cons key focus subrowTail subrow
-       , CommutativeRingRecord rowlistTail row subrowTail
-       , CommutativeRing focus
-       )
-    => CommutativeRingRecord (RL.Cons key focus rowlistTail) row subrow
+instance commutativeRingRecordCons ::
+  ( IsSymbol key
+  , Row.Cons key focus subrowTail subrow
+  , CommutativeRingRecord rowlistTail row subrowTail
+  , CommutativeRing focus
+  ) =>
+  CommutativeRingRecord (RL.Cons key focus rowlistTail) row subrow

--- a/src/Data/Eq.purs
+++ b/src/Data/Eq.purs
@@ -1,7 +1,14 @@
 module Data.Eq
-  ( class Eq, eq, (==), notEq, (/=)
-  , class Eq1, eq1, notEq1
-  , class EqRecord, eqRecord
+  ( class Eq
+  , eq
+  , (==)
+  , notEq
+  , (/=)
+  , class Eq1
+  , eq1
+  , notEq1
+  , class EqRecord
+  , eqRecord
   ) where
 
 import Data.HeytingAlgebra ((&&))
@@ -95,20 +102,20 @@ notEq1 x y = (x `eq1` y) == false
 -- | the `Eq` instance for records.
 class EqRecord :: RL.RowList Type -> Row Type -> Constraint
 class EqRecord rowlist row where
-  eqRecord :: forall rlproxy. rlproxy rowlist -> Record row -> Record row -> Boolean
+  eqRecord :: Proxy rowlist -> Record row -> Record row -> Boolean
 
 instance eqRowNil :: EqRecord RL.Nil row where
   eqRecord _ _ _ = true
 
-instance eqRowCons
-    :: ( EqRecord rowlistTail row
-       , Row.Cons key focus rowTail row
-       , IsSymbol key
-       , Eq focus
-       )
-    => EqRecord (RL.Cons key focus rowlistTail) row where
+instance eqRowCons ::
+  ( EqRecord rowlistTail row
+  , Row.Cons key focus rowTail row
+  , IsSymbol key
+  , Eq focus
+  ) =>
+  EqRecord (RL.Cons key focus rowlistTail) row where
   eqRecord _ ra rb = (get ra == get rb) && tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      get = unsafeGet key :: Record row -> focus
-      tail = eqRecord (Proxy :: Proxy rowlistTail) ra rb
+    key = reflectSymbol (Proxy :: Proxy key)
+    get = unsafeGet key :: Record row -> focus
+    tail = eqRecord (Proxy :: Proxy rowlistTail) ra rb

--- a/src/Data/Eq.purs
+++ b/src/Data/Eq.purs
@@ -18,7 +18,7 @@ import Data.Void (Void)
 import Prim.Row as Row
 import Prim.RowList as RL
 import Record.Unsafe (unsafeGet)
-import Type.Proxy (Proxy(..), Proxy2, Proxy3)
+import Type.Proxy (Proxy(..))
 
 -- | The `Eq` type class represents types which support decidable equality.
 -- |
@@ -72,12 +72,6 @@ instance eqRec :: (RL.RowToList row list, EqRecord list row) => Eq (Record row) 
   eq = eqRecord (Proxy :: Proxy list)
 
 instance eqProxy :: Eq (Proxy a) where
-  eq _ _ = true
-
-instance eqProxy2 :: Eq (Proxy2 a) where
-  eq _ _ = true
-
-instance eqProxy3 :: Eq (Proxy3 a) where
   eq _ _ = true
 
 foreign import eqBooleanImpl :: Boolean -> Boolean -> Boolean

--- a/src/Data/HeytingAlgebra.purs
+++ b/src/Data/HeytingAlgebra.purs
@@ -22,7 +22,7 @@ import Data.Unit (Unit, unit)
 import Prim.Row as Row
 import Prim.RowList as RL
 import Record.Unsafe (unsafeGet, unsafeSet)
-import Type.Proxy (Proxy(..), Proxy2(..), Proxy3(..))
+import Type.Proxy (Proxy(..))
 
 -- | The `HeytingAlgebra` type class represents types that are bounded lattices with
 -- | an implication operator such that the following laws hold:
@@ -91,22 +91,6 @@ instance heytingAlgebraProxy :: HeytingAlgebra (Proxy a) where
   ff = Proxy
   not _ = Proxy
   tt = Proxy
-
-instance heytingAlgebraProxy2 :: HeytingAlgebra (Proxy2 a) where
-  conj _ _ = Proxy2
-  disj _ _ = Proxy2
-  implies _ _ = Proxy2
-  ff = Proxy2
-  not _ = Proxy2
-  tt = Proxy2
-
-instance heytingAlgebraProxy3 :: HeytingAlgebra (Proxy3 a) where
-  conj _ _ = Proxy3
-  disj _ _ = Proxy3
-  implies _ _ = Proxy3
-  ff = Proxy3
-  not _ = Proxy3
-  tt = Proxy3
 
 instance heytingAlgebraRecord :: (RL.RowToList row list, HeytingAlgebraRecord list row row) => HeytingAlgebra (Record row) where
   ff = ffRecord (Proxy :: Proxy list) (Proxy :: Proxy row)

--- a/src/Data/HeytingAlgebra.purs
+++ b/src/Data/HeytingAlgebra.purs
@@ -1,6 +1,20 @@
 module Data.HeytingAlgebra
-  ( class HeytingAlgebra, tt, ff, implies, conj, disj, not, (&&), (||)
-  , class HeytingAlgebraRecord, ffRecord, ttRecord, impliesRecord, conjRecord, disjRecord, notRecord
+  ( class HeytingAlgebra
+  , tt
+  , ff
+  , implies
+  , conj
+  , disj
+  , not
+  , (&&)
+  , (||)
+  , class HeytingAlgebraRecord
+  , ffRecord
+  , ttRecord
+  , impliesRecord
+  , conjRecord
+  , disjRecord
+  , notRecord
   ) where
 
 import Data.Symbol (class IsSymbol, reflectSymbol)
@@ -95,12 +109,12 @@ instance heytingAlgebraProxy3 :: HeytingAlgebra (Proxy3 a) where
   tt = Proxy3
 
 instance heytingAlgebraRecord :: (RL.RowToList row list, HeytingAlgebraRecord list row row) => HeytingAlgebra (Record row) where
-  ff = ffRecord  (Proxy :: Proxy list) (Proxy :: Proxy row)
-  tt = ttRecord  (Proxy :: Proxy list) (Proxy :: Proxy row)
-  conj = conjRecord  (Proxy :: Proxy list)
-  disj = disjRecord  (Proxy :: Proxy list)
-  implies = impliesRecord  (Proxy :: Proxy list)
-  not = notRecord  (Proxy :: Proxy list)
+  ff = ffRecord (Proxy :: Proxy list) (Proxy :: Proxy row)
+  tt = ttRecord (Proxy :: Proxy list) (Proxy :: Proxy row)
+  conj = conjRecord (Proxy :: Proxy list)
+  disj = disjRecord (Proxy :: Proxy list)
+  implies = impliesRecord (Proxy :: Proxy list)
+  not = notRecord (Proxy :: Proxy list)
 
 foreign import boolConj :: Boolean -> Boolean -> Boolean
 foreign import boolDisj :: Boolean -> Boolean -> Boolean
@@ -110,12 +124,12 @@ foreign import boolNot :: Boolean -> Boolean
 -- | to implement the `HeytingAlgebra` instance for records.
 class HeytingAlgebraRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class HeytingAlgebraRecord rowlist row subrow | rowlist -> subrow where
-  ffRecord :: forall rlproxy rproxy. rlproxy rowlist -> rproxy row -> Record subrow
-  ttRecord :: forall rlproxy rproxy. rlproxy rowlist -> rproxy row -> Record subrow
-  impliesRecord :: forall rlproxy. rlproxy rowlist -> Record row -> Record row -> Record subrow
-  disjRecord :: forall rlproxy. rlproxy rowlist -> Record row -> Record row -> Record subrow
-  conjRecord :: forall rlproxy. rlproxy rowlist -> Record row -> Record row -> Record subrow
-  notRecord :: forall rlproxy. rlproxy rowlist -> Record row -> Record subrow
+  ffRecord :: Proxy rowlist -> Proxy row -> Record subrow
+  ttRecord :: Proxy rowlist -> Proxy row -> Record subrow
+  impliesRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
+  disjRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
+  conjRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
+  notRecord :: Proxy rowlist -> Record row -> Record subrow
 
 instance heytingAlgebraRecordNil :: HeytingAlgebraRecord RL.Nil row () where
   conjRecord _ _ _ = {}
@@ -125,50 +139,49 @@ instance heytingAlgebraRecordNil :: HeytingAlgebraRecord RL.Nil row () where
   notRecord _ _ = {}
   ttRecord _ _ = {}
 
-instance heytingAlgebraRecordCons
-    :: ( IsSymbol key
-       , Row.Cons key focus subrowTail subrow
-       , HeytingAlgebraRecord rowlistTail row subrowTail
-       , HeytingAlgebra focus
-       )
-    => HeytingAlgebraRecord (RL.Cons key focus rowlistTail) row subrow where
+instance heytingAlgebraRecordCons ::
+  ( IsSymbol key
+  , Row.Cons key focus subrowTail subrow
+  , HeytingAlgebraRecord rowlistTail row subrowTail
+  , HeytingAlgebra focus
+  ) =>
+  HeytingAlgebraRecord (RL.Cons key focus rowlistTail) row subrow where
   conjRecord _ ra rb = insert (conj (get ra) (get rb)) tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      get = unsafeGet key :: Record row -> focus
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-      tail = conjRecord (Proxy :: Proxy rowlistTail) ra rb
+    key = reflectSymbol (Proxy :: Proxy key)
+    get = unsafeGet key :: Record row -> focus
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    tail = conjRecord (Proxy :: Proxy rowlistTail) ra rb
 
   disjRecord _ ra rb = insert (disj (get ra) (get rb)) tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      get = unsafeGet key :: Record row -> focus
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-      tail = disjRecord (Proxy :: Proxy rowlistTail) ra rb
+    key = reflectSymbol (Proxy :: Proxy key)
+    get = unsafeGet key :: Record row -> focus
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    tail = disjRecord (Proxy :: Proxy rowlistTail) ra rb
 
   impliesRecord _ ra rb = insert (implies (get ra) (get rb)) tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      get = unsafeGet key :: Record row -> focus
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-      tail = impliesRecord (Proxy :: Proxy rowlistTail) ra rb
+    key = reflectSymbol (Proxy :: Proxy key)
+    get = unsafeGet key :: Record row -> focus
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    tail = impliesRecord (Proxy :: Proxy rowlistTail) ra rb
 
   ffRecord _ row = insert ff tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-      tail = ffRecord (Proxy :: Proxy rowlistTail) row
+    key = reflectSymbol (Proxy :: Proxy key)
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    tail = ffRecord (Proxy :: Proxy rowlistTail) row
 
-  notRecord _ row
-    = insert (not (get row)) tail
+  notRecord _ row = insert (not (get row)) tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      get = unsafeGet key :: Record row -> focus
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-      tail = notRecord (Proxy :: Proxy rowlistTail) row
+    key = reflectSymbol (Proxy :: Proxy key)
+    get = unsafeGet key :: Record row -> focus
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    tail = notRecord (Proxy :: Proxy rowlistTail) row
 
   ttRecord _ row = insert tt tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-      tail = ttRecord (Proxy :: Proxy rowlistTail) row
+    key = reflectSymbol (Proxy :: Proxy key)
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    tail = ttRecord (Proxy :: Proxy rowlistTail) row

--- a/src/Data/Monoid.purs
+++ b/src/Data/Monoid.purs
@@ -1,9 +1,11 @@
 module Data.Monoid
-  ( class Monoid, mempty
+  ( class Monoid
+  , mempty
   , power
   , guard
   , module Data.Semigroup
-  , class MonoidRecord, memptyRecord
+  , class MonoidRecord
+  , memptyRecord
   ) where
 
 import Data.Boolean (otherwise)
@@ -99,21 +101,20 @@ guard false _ = mempty
 -- | implement the `Monoid` instance for records.
 class MonoidRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class SemigroupRecord rowlist row subrow <= MonoidRecord rowlist row subrow | rowlist -> row subrow where
-  memptyRecord :: forall rlproxy. rlproxy rowlist -> Record subrow
+  memptyRecord :: Proxy rowlist -> Record subrow
 
 instance monoidRecordNil :: MonoidRecord RL.Nil row () where
   memptyRecord _ = {}
 
-instance monoidRecordCons
-    :: ( IsSymbol key
-       , Monoid focus
-       , Row.Cons key focus subrowTail subrow
-       , MonoidRecord rowlistTail row subrowTail
-       )
-    => MonoidRecord (RL.Cons key focus rowlistTail) row subrow where
-  memptyRecord _
-    = insert mempty tail
+instance monoidRecordCons ::
+  ( IsSymbol key
+  , Monoid focus
+  , Row.Cons key focus subrowTail subrow
+  , MonoidRecord rowlistTail row subrowTail
+  ) =>
+  MonoidRecord (RL.Cons key focus rowlistTail) row subrow where
+  memptyRecord _ = insert mempty tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-      tail = memptyRecord (Proxy :: Proxy rowlistTail)
+    key = reflectSymbol (Proxy :: Proxy key)
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    tail = memptyRecord (Proxy :: Proxy rowlistTail)

--- a/src/Data/Ord.purs
+++ b/src/Data/Ord.purs
@@ -1,18 +1,26 @@
 module Data.Ord
-  ( class Ord, compare
-  , class Ord1, compare1
-  , lessThan, (<)
-  , lessThanOrEq, (<=)
-  , greaterThan, (>)
-  , greaterThanOrEq, (>=)
+  ( class Ord
+  , compare
+  , class Ord1
+  , compare1
+  , lessThan
+  , (<)
+  , lessThanOrEq
+  , (<=)
+  , greaterThan
+  , (>)
+  , greaterThanOrEq
+  , (>=)
   , comparing
-  , min, max
+  , min
+  , max
   , clamp
   , between
   , abs
   , signum
   , module Data.Ordering
-  , class OrdRecord, compareRecord
+  , class OrdRecord
+  , compareRecord
   ) where
 
 import Data.Eq (class Eq, class Eq1, class EqRecord, (/=))
@@ -125,10 +133,10 @@ instance ordOrdering :: Ord Ordering where
   compare LT LT = EQ
   compare EQ EQ = EQ
   compare GT GT = EQ
-  compare LT _  = LT
+  compare LT _ = LT
   compare EQ LT = GT
   compare EQ GT = LT
-  compare GT _  = GT
+  compare GT _ = GT
 
 -- | Test whether one value is _strictly less than_ another.
 lessThan :: forall a. Ord a => a -> a -> Boolean
@@ -228,30 +236,29 @@ instance ord1Array :: Ord1 Array where
 
 class OrdRecord :: RL.RowList Type -> Row Type -> Constraint
 class EqRecord rowlist row <= OrdRecord rowlist row where
-  compareRecord :: forall rlproxy. rlproxy rowlist -> Record row -> Record row -> Ordering
+  compareRecord :: Proxy rowlist -> Record row -> Record row -> Ordering
 
 instance ordRecordNil :: OrdRecord RL.Nil row where
   compareRecord _ _ _ = EQ
 
-instance ordRecordCons
-    :: ( OrdRecord rowlistTail row
-       , Row.Cons key focus rowTail row
-       , IsSymbol key
-       , Ord focus
-       )
-    => OrdRecord (RL.Cons key focus rowlistTail) row where
-  compareRecord _ ra rb
-    = if left /= EQ
-        then left
-        else compareRecord (Proxy :: Proxy rowlistTail) ra rb
+instance ordRecordCons ::
+  ( OrdRecord rowlistTail row
+  , Row.Cons key focus rowTail row
+  , IsSymbol key
+  , Ord focus
+  ) =>
+  OrdRecord (RL.Cons key focus rowlistTail) row where
+  compareRecord _ ra rb =
+    if left /= EQ then left
+    else compareRecord (Proxy :: Proxy rowlistTail) ra rb
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      unsafeGet' = unsafeGet :: String -> Record row -> focus
-      left = unsafeGet' key ra `compare` unsafeGet' key rb
+    key = reflectSymbol (Proxy :: Proxy key)
+    unsafeGet' = unsafeGet :: String -> Record row -> focus
+    left = unsafeGet' key ra `compare` unsafeGet' key rb
 
-instance ordRecord
-    :: ( RL.RowToList row list
-       , OrdRecord list row
-       )
-    => Ord (Record row) where
+instance ordRecord ::
+  ( RL.RowToList row list
+  , OrdRecord list row
+  ) =>
+  Ord (Record row) where
   compare = compareRecord (Proxy :: Proxy list)

--- a/src/Data/Ord.purs
+++ b/src/Data/Ord.purs
@@ -32,7 +32,7 @@ import Data.Void (Void)
 import Prim.Row as Row
 import Prim.RowList as RL
 import Record.Unsafe (unsafeGet)
-import Type.Proxy (Proxy(..), Proxy2, Proxy3)
+import Type.Proxy (Proxy(..))
 
 -- | The `Ord` type class represents types which support comparisons with a
 -- | _total order_.
@@ -70,12 +70,6 @@ instance ordVoid :: Ord Void where
   compare _ _ = EQ
 
 instance ordProxy :: Ord (Proxy a) where
-  compare _ _ = EQ
-
-instance ordProxy2 :: Ord (Proxy2 a) where
-  compare _ _ = EQ
-
-instance ordProxy3 :: Ord (Proxy3 a) where
   compare _ _ = EQ
 
 instance ordArray :: Ord a => Ord (Array a) where

--- a/src/Data/Ring.purs
+++ b/src/Data/Ring.purs
@@ -14,7 +14,7 @@ import Data.Unit (Unit, unit)
 import Prim.Row as Row
 import Prim.RowList as RL
 import Record.Unsafe (unsafeGet, unsafeSet)
-import Type.Proxy (Proxy(..), Proxy2(..), Proxy3(..))
+import Type.Proxy (Proxy(..))
 
 -- | The `Ring` class is for types that support addition, multiplication,
 -- | and subtraction operations.
@@ -43,12 +43,6 @@ instance ringFn :: Ring b => Ring (a -> b) where
 
 instance ringProxy :: Ring (Proxy a) where
   sub _ _ = Proxy
-
-instance ringProxy2 :: Ring (Proxy2 a) where
-  sub _ _ = Proxy2
-
-instance ringProxy3 :: Ring (Proxy3 a) where
-  sub _ _ = Proxy3
 
 instance ringRecord :: (RL.RowToList row list, RingRecord list row row) => Ring (Record row) where
   sub = subRecord (Proxy :: Proxy list)

--- a/src/Data/Ring.purs
+++ b/src/Data/Ring.purs
@@ -1,7 +1,11 @@
 module Data.Ring
-  ( class Ring, sub, negate, (-)
+  ( class Ring
+  , sub
+  , negate
+  , (-)
   , module Data.Semiring
-  , class RingRecord, subRecord
+  , class RingRecord
+  , subRecord
   ) where
 
 import Data.Semiring (class Semiring, class SemiringRecord, add, mul, one, zero, (*), (+))
@@ -60,21 +64,21 @@ foreign import numSub :: Number -> Number -> Number
 -- | implement the `Ring` instance for records.
 class RingRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class SemiringRecord rowlist row subrow <= RingRecord rowlist row subrow | rowlist -> subrow where
-  subRecord :: forall rlproxy. rlproxy rowlist -> Record row -> Record row -> Record subrow
+  subRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
 
 instance ringRecordNil :: RingRecord RL.Nil row () where
   subRecord _ _ _ = {}
 
-instance ringRecordCons
-    :: ( IsSymbol key
-       , Row.Cons key focus subrowTail subrow
-       , RingRecord rowlistTail row subrowTail
-       , Ring focus
-       )
-    => RingRecord (RL.Cons key focus rowlistTail) row subrow where
+instance ringRecordCons ::
+  ( IsSymbol key
+  , Row.Cons key focus subrowTail subrow
+  , RingRecord rowlistTail row subrowTail
+  , Ring focus
+  ) =>
+  RingRecord (RL.Cons key focus rowlistTail) row subrow where
   subRecord _ ra rb = insert (get ra - get rb) tail
     where
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-      key = reflectSymbol (Proxy :: Proxy key)
-      get = unsafeGet key :: Record row -> focus
-      tail = subRecord (Proxy :: Proxy rowlistTail) ra rb
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    key = reflectSymbol (Proxy :: Proxy key)
+    get = unsafeGet key :: Record row -> focus
+    tail = subRecord (Proxy :: Proxy rowlistTail) ra rb

--- a/src/Data/Semigroup.purs
+++ b/src/Data/Semigroup.purs
@@ -1,6 +1,9 @@
 module Data.Semigroup
-  ( class Semigroup, append, (<>)
-  , class SemigroupRecord, appendRecord
+  ( class Semigroup
+  , append
+  , (<>)
+  , class SemigroupRecord
+  , appendRecord
   ) where
 
 import Data.Symbol (class IsSymbol, reflectSymbol)
@@ -65,23 +68,23 @@ foreign import concatArray :: forall a. Array a -> Array a -> Array a
 
 -- | A class for records where all fields have `Semigroup` instances, used to
 -- | implement the `Semigroup` instance for records.
-class SemigroupRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint  
+class SemigroupRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class SemigroupRecord rowlist row subrow | rowlist -> subrow where
-  appendRecord :: forall rlproxy. rlproxy rowlist -> Record row -> Record row -> Record subrow
+  appendRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
 
 instance semigroupRecordNil :: SemigroupRecord RL.Nil row () where
   appendRecord _ _ _ = {}
 
-instance semigroupRecordCons
-    :: ( IsSymbol key
-       , Row.Cons key focus subrowTail subrow
-       , SemigroupRecord rowlistTail row subrowTail
-       , Semigroup focus
-       )
-    => SemigroupRecord (RL.Cons key focus rowlistTail) row subrow where
+instance semigroupRecordCons ::
+  ( IsSymbol key
+  , Row.Cons key focus subrowTail subrow
+  , SemigroupRecord rowlistTail row subrowTail
+  , Semigroup focus
+  ) =>
+  SemigroupRecord (RL.Cons key focus rowlistTail) row subrow where
   appendRecord _ ra rb = insert (get ra <> get rb) tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      get = unsafeGet key :: Record row -> focus
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-      tail = appendRecord (Proxy :: Proxy rowlistTail) ra rb
+    key = reflectSymbol (Proxy :: Proxy key)
+    get = unsafeGet key :: Record row -> focus
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    tail = appendRecord (Proxy :: Proxy rowlistTail) ra rb

--- a/src/Data/Semigroup.purs
+++ b/src/Data/Semigroup.purs
@@ -12,7 +12,7 @@ import Data.Void (Void, absurd)
 import Prim.Row as Row
 import Prim.RowList as RL
 import Record.Unsafe (unsafeGet, unsafeSet)
-import Type.Proxy (Proxy(..), Proxy2(..), Proxy3(..))
+import Type.Proxy (Proxy(..))
 
 -- | The `Semigroup` type class identifies an associative operation on a type.
 -- |
@@ -53,12 +53,6 @@ instance semigroupArray :: Semigroup (Array a) where
 
 instance semigroupProxy :: Semigroup (Proxy a) where
   append _ _ = Proxy
-
-instance semigroupProxy2 :: Semigroup (Proxy2 a) where
-  append _ _ = Proxy2
-
-instance semigroupProxy3 :: Semigroup (Proxy3 a) where
-  append _ _ = Proxy3
 
 instance semigroupRecord :: (RL.RowToList row list, SemigroupRecord list row row) => Semigroup (Record row) where
   append = appendRecord (Proxy :: Proxy list)

--- a/src/Data/Semiring.purs
+++ b/src/Data/Semiring.purs
@@ -18,7 +18,7 @@ import Data.Unit (Unit, unit)
 import Prim.Row as Row
 import Prim.RowList as RL
 import Record.Unsafe (unsafeGet, unsafeSet)
-import Type.Proxy (Proxy(..), Proxy2(..), Proxy3(..))
+import Type.Proxy (Proxy(..))
 
 -- | The `Semiring` class is for types that support an addition and
 -- | multiplication operation.
@@ -79,18 +79,6 @@ instance semiringProxy :: Semiring (Proxy a) where
   mul _ _ = Proxy
   one = Proxy
   zero = Proxy
-
-instance semiringProxy2 :: Semiring (Proxy2 a) where
-  add _ _ = Proxy2
-  mul _ _ = Proxy2
-  one = Proxy2
-  zero = Proxy2
-
-instance semiringProxy3 :: Semiring (Proxy3 a) where
-  add _ _ = Proxy3
-  mul _ _ = Proxy3
-  one = Proxy3
-  zero = Proxy3
 
 instance semiringRecord :: (RL.RowToList row list, SemiringRecord list row row) => Semiring (Record row) where
   add = addRecord (Proxy :: Proxy list)

--- a/src/Data/Semiring.purs
+++ b/src/Data/Semiring.purs
@@ -1,6 +1,16 @@
 module Data.Semiring
-  ( class Semiring, add, (+), zero, mul, (*), one
-  , class SemiringRecord, addRecord, mulRecord, oneRecord, zeroRecord
+  ( class Semiring
+  , add
+  , (+)
+  , zero
+  , mul
+  , (*)
+  , one
+  , class SemiringRecord
+  , addRecord
+  , mulRecord
+  , oneRecord
+  , zeroRecord
   ) where
 
 import Data.Symbol (class IsSymbol, reflectSymbol)
@@ -32,10 +42,10 @@ import Type.Proxy (Proxy(..), Proxy2(..), Proxy3(..))
 -- | overflows, and in the case of `Number`, the presence of `NaN` and
 -- | `Infinity` values. The behaviour is unspecified in these cases.
 class Semiring a where
-  add  :: a -> a -> a
+  add :: a -> a -> a
   zero :: a
-  mul  :: a -> a -> a
-  one  :: a
+  mul :: a -> a -> a
+  one :: a
 
 infixl 6 add as +
 infixl 7 mul as *
@@ -97,46 +107,46 @@ foreign import numMul :: Number -> Number -> Number
 -- | implement the `Semiring` instance for records.
 class SemiringRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class SemiringRecord rowlist row subrow | rowlist -> subrow where
-  addRecord :: forall rlproxy. rlproxy rowlist -> Record row -> Record row -> Record subrow
-  mulRecord :: forall rlproxy. rlproxy rowlist -> Record row -> Record row -> Record subrow
-  oneRecord :: forall rlproxy rproxy. rlproxy rowlist -> rproxy row -> Record subrow
-  zeroRecord :: forall rlproxy rproxy. rlproxy rowlist -> rproxy row -> Record subrow
+  addRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
+  mulRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
+  oneRecord :: Proxy rowlist -> Proxy row -> Record subrow
+  zeroRecord :: Proxy rowlist -> Proxy row -> Record subrow
 
 instance semiringRecordNil :: SemiringRecord RL.Nil row () where
-  addRecord  _ _ _ = {}
-  mulRecord  _ _ _ = {}
-  oneRecord  _ _ = {}
+  addRecord _ _ _ = {}
+  mulRecord _ _ _ = {}
+  oneRecord _ _ = {}
   zeroRecord _ _ = {}
 
-instance semiringRecordCons
-    :: ( IsSymbol key
-       , Row.Cons key focus subrowTail subrow
-       , SemiringRecord rowlistTail row subrowTail
-       , Semiring focus
-       )
-    => SemiringRecord (RL.Cons key focus rowlistTail) row subrow where
+instance semiringRecordCons ::
+  ( IsSymbol key
+  , Row.Cons key focus subrowTail subrow
+  , SemiringRecord rowlistTail row subrowTail
+  , Semiring focus
+  ) =>
+  SemiringRecord (RL.Cons key focus rowlistTail) row subrow where
   addRecord _ ra rb = insert (get ra + get rb) tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      get = unsafeGet key :: Record row -> focus
-      tail = addRecord (Proxy :: Proxy rowlistTail) ra rb
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    key = reflectSymbol (Proxy :: Proxy key)
+    get = unsafeGet key :: Record row -> focus
+    tail = addRecord (Proxy :: Proxy rowlistTail) ra rb
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
 
   mulRecord _ ra rb = insert (get ra * get rb) tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      get = unsafeGet key :: Record row -> focus
-      tail = mulRecord (Proxy :: Proxy rowlistTail) ra rb
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    key = reflectSymbol (Proxy :: Proxy key)
+    get = unsafeGet key :: Record row -> focus
+    tail = mulRecord (Proxy :: Proxy rowlistTail) ra rb
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
 
   oneRecord _ _ = insert one tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      tail = oneRecord (Proxy :: Proxy rowlistTail) (Proxy :: Proxy row)
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    key = reflectSymbol (Proxy :: Proxy key)
+    tail = oneRecord (Proxy :: Proxy rowlistTail) (Proxy :: Proxy row)
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
 
   zeroRecord _ _ = insert zero tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      tail = zeroRecord (Proxy :: Proxy rowlistTail) (Proxy :: Proxy row)
-      insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
+    key = reflectSymbol (Proxy :: Proxy key)
+    tail = zeroRecord (Proxy :: Proxy rowlistTail) (Proxy :: Proxy row)
+    insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow

--- a/src/Data/Show.purs
+++ b/src/Data/Show.purs
@@ -8,7 +8,7 @@ module Data.Show
 import Data.Symbol (class IsSymbol, reflectSymbol)
 import Prim.RowList as RL
 import Record.Unsafe (unsafeGet)
-import Type.Proxy (Proxy(..), Proxy2, Proxy3)
+import Type.Proxy (Proxy(..))
 
 -- | The `Show` type class represents those types which can be converted into
 -- | a human-readable `String` representation.
@@ -40,12 +40,6 @@ instance showArray :: Show a => Show (Array a) where
 
 instance showProxy :: Show (Proxy a) where
   show _ = "Proxy"
-
-instance showProxy2 :: Show (Proxy2 a) where
-  show _ = "Proxy2"
-
-instance showProxy3 :: Show (Proxy3 a) where
-  show _ = "Proxy3"
 
 instance showRecord :: (RL.RowToList rs ls, ShowRecordFields ls rs) => Show (Record rs) where
   show record = case showRecordFields (Proxy :: Proxy ls) record of

--- a/src/Data/Show.purs
+++ b/src/Data/Show.purs
@@ -1,6 +1,8 @@
 module Data.Show
-  ( class Show, show
-  , class ShowRecordFields, showRecordFields
+  ( class Show
+  , show
+  , class ShowRecordFields
+  , showRecordFields
   ) where
 
 import Data.Symbol (class IsSymbol, reflectSymbol)
@@ -48,29 +50,28 @@ instance showProxy3 :: Show (Proxy3 a) where
 instance showRecord :: (RL.RowToList rs ls, ShowRecordFields ls rs) => Show (Record rs) where
   show record = case showRecordFields (Proxy :: Proxy ls) record of
     [] -> "{}"
-    fields -> join " " ["{", join ", " fields, "}"]
+    fields -> join " " [ "{", join ", " fields, "}" ]
 
 -- | A class for records where all fields have `Show` instances, used to
 -- | implement the `Show` instance for records.
 class ShowRecordFields :: RL.RowList Type -> Row Type -> Constraint
 class ShowRecordFields rowlist row where
-  showRecordFields :: forall rlproxy. rlproxy rowlist -> Record row -> Array String
+  showRecordFields :: Proxy rowlist -> Record row -> Array String
 
 instance showRecordFieldsNil :: ShowRecordFields RL.Nil row where
   showRecordFields _ _ = []
 
-instance showRecordFieldsCons
-    :: ( IsSymbol key
-       , ShowRecordFields rowlistTail row
-       , Show focus
-       )
-    => ShowRecordFields (RL.Cons key focus rowlistTail) row where
-  showRecordFields _ record
-    = cons (join ": " [ key, show focus ]) tail
+instance showRecordFieldsCons ::
+  ( IsSymbol key
+  , ShowRecordFields rowlistTail row
+  , Show focus
+  ) =>
+  ShowRecordFields (RL.Cons key focus rowlistTail) row where
+  showRecordFields _ record = cons (join ": " [ key, show focus ]) tail
     where
-      key = reflectSymbol (Proxy :: Proxy key)
-      focus = unsafeGet key record :: focus
-      tail = showRecordFields (Proxy :: Proxy rowlistTail) record
+    key = reflectSymbol (Proxy :: Proxy key)
+    focus = unsafeGet key record :: focus
+    tail = showRecordFields (Proxy :: Proxy rowlistTail) record
 
 foreign import showIntImpl :: Int -> String
 foreign import showNumberImpl :: Number -> String

--- a/src/Data/Symbol.purs
+++ b/src/Data/Symbol.purs
@@ -14,21 +14,17 @@ data SProxy sym = SProxy
 
 -- | A class for known symbols
 class IsSymbol (sym :: Symbol) where
-  -- Note: Before v0.14.0, we did not have polykinds. Thus, we needed
-  -- kind-specific proxy types to pass a Symbol around.
-  -- Once v0.14.0 was released, we could use the kind-generic `Proxy` type
-  -- instead. However, to reduce code breakage, we're using
-  -- `forall proxy. proxy sym` here so that `SProxy` code will still compile.
-  -- When PureScript makes a new breaking release after the v0.14.0 release,
-  -- this type signature will be updated to `Proxy sym -> String`.
-  reflectSymbol :: forall proxy. proxy sym -> String
+  reflectSymbol :: Proxy sym -> String
 
 -- local definition for use in `reifySymbol`
 foreign import unsafeCoerce :: forall a b. a -> b
 
-reifySymbol :: forall proxy r. String -> (forall sym. IsSymbol sym => proxy sym -> r) -> r
-reifySymbol s f = coerce f { reflectSymbol: \_ -> s } Proxy where
+reifySymbol :: forall r. String -> (forall sym. IsSymbol sym => Proxy sym -> r) -> r
+reifySymbol s f = coerce f { reflectSymbol: \_ -> s } Proxy
+  where
   coerce
-    :: (forall sym1. IsSymbol sym1              => proxy sym1 -> r)
-    -> { reflectSymbol :: Proxy "" -> String } -> Proxy ""   -> r
+    :: (forall sym1. IsSymbol sym1 => Proxy sym1 -> r)
+    -> { reflectSymbol :: Proxy "" -> String }
+    -> Proxy ""
+    -> r
   coerce = unsafeCoerce

--- a/src/Type/Proxy.purs
+++ b/src/Type/Proxy.purs
@@ -51,12 +51,3 @@ module Type.Proxy where
 -- | Proxy type for all `kind`s.
 data Proxy :: forall k. k -> Type
 data Proxy a = Proxy
-
--- | Value proxy for kind `Type -> Type` types.
--- | **Deprecated as of v0.14.0 PureScript release**: use `Proxy` instead.
-data Proxy2 :: (Type -> Type) -> Type
-data Proxy2 f = Proxy2
-
--- | Value proxy for kind `Type -> Type -> Type` types.
--- | **Deprecated as of v0.14.0 PureScript release**: use `Proxy` instead.
-data Proxy3 (a :: Type -> Type -> Type) = Proxy3


### PR DESCRIPTION
**Description of the change**

Fixes #231 by changing `forall proxy. proxy SomeKind -> ..` to just `Proxy SomeKind`.

Also removes `Proxy2` and `Proxy3` types since `Proxy` is enough now.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
