### PR TITLE
Change NoConstructors to newtype Void

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 - Migrated FFI to ES Modules (#287 by @kl0tl and @JordanMartinez)
+- Change Generic Rep's `NoConstructors` to newtype `Void` (#282 by @JordanMartinez)
 
 New features:
 

--- a/src/Data/Generic/Rep.purs
+++ b/src/Data/Generic/Rep.purs
@@ -14,10 +14,11 @@ module Data.Generic.Rep
 import Data.Semigroup ((<>))
 import Data.Show (class Show, show)
 import Data.Symbol (class IsSymbol, reflectSymbol)
+import Data.Void (Void)
 import Type.Proxy (Proxy(..))
 
 -- | A representation for types with no constructors.
-data NoConstructors
+newtype NoConstructors = NoConstructors Void
 
 -- | A representation for constructors with no arguments.
 data NoArguments = NoArguments


### PR DESCRIPTION
**Description of the change**

Fixes #247. I think `purescript-newtype` would need to add a `Newtype` instance for `NoConstructors`...?

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
