### PR TITLE
Migrate to `purs-changelog` for handling changelog file

### DIFF
--- a/CHANGELOG.d/README.md
+++ b/CHANGELOG.d/README.md
@@ -1,0 +1,77 @@
+# About
+
+This directory contains changelog entries for work that has not yet been
+released. When a release goes out, these files will be concatenated and
+prepended to `CHANGELOG.md` in a new section for that release.
+
+## For Maintainers
+
+See https://github.com/JordanMartinez/purescript-up-changelog for details of this process.
+
+## For Contributors
+
+When making a new PR, do the following steps. Each is described in the sections that follow:
+1. Add a new file to this directory where the file name follows the naming convention described below
+1. Fill that file with the proper content
+
+To ensure you're doing it correctly, see the [Checklist](#checklist)
+
+### File Naming Convention
+
+The file should be named `{PREFIX}_{SLUG}.md`.
+
+`{PREFIX}` is one of the following:
+* `breaking`: for breaking changes
+* `feature`: for new features
+* `fix`: for bug fixes
+* `internal`: for work that will not directly affect users of the project
+* `misc`: for anything else that needs to be logged
+
+`{SLUG}` should be a short description of the work you've done. The name has no
+impact on the final CHANGELOG.md.
+
+Some example names:
+* `fix_issue-9876.md`
+* `breaking_deprecate-classes.md`
+* `misc_add-forum-to-readme.md`
+
+### File Contents
+
+The contents of the file can be as brief as:
+
+```markdown
+* A short message, like the title of your commit
+```
+
+Please remember the initial `*`! These files will all be concatenated into
+lists.
+
+If you have more to say about your work, indent additional lines like so:
+
+``````markdown
+* A short message, like the title of your commit
+
+  Here is a longer explanation of what this is all about. Of course, this file
+  is Markdown, so feel free to use *formatting*
+
+  ```
+  and code blocks
+  ```
+
+  if it makes your work more understandable.
+``````
+
+You do not have to edit your changelog file to include a reference to your PR.
+The `CHANGELOG.md` updating script will do this automatically and credit you.
+
+### Checklist
+
+Use this checklist to help you remember to do everything described above.
+
+- [ ] A new file has been added to `CHANGELOG.d`
+- [ ] The file name starts with one of the `{PREFIX}` values above.
+- [ ] The file's content does not reference the PR number that introduces it
+- [ ] The file's first line (i.e. title line) starts with `* ` followed by a short description
+- If the file contains content after the first line (i.e. body part):
+    - [ ] the file has a blank line separating the title line from the body part
+    - [ ] each line in the body part is indented by at least two spaces


### PR DESCRIPTION
**Description of the change**

Uses [`purs-changelog`](https://github.com/purescript-contrib/purescript-up-changelog) to handle the changelog for this repo. (This tool is a port of the `update-changelog.hs` script used in the PureScript repo). The benefit of this change is that we will no longer get merge conflicts in the `CHANGELOG.md` file when merging multiple PRs in a short time period. To see an example of what using `purs-changelog` for updating a changelog looks like, see [this commit](https://github.com/purescript-contrib/purescript-up-changelog/pull/13/commits/3a3e57e46c87cc2406f271845c8f1f9763eccd65)

Moreover, the first checkbox in the PR template list below will no longer require authors to indicate the PR number (so, no more "open a PR, see what the PR number is, and push a commit for that number).

Lastly, when we need to update the changelog for a new release, one only needs to run `purs-changelog update` so long as the URL for the `origin` remote name (i.e. `git remote -v`) refers to this repo and not a fork.

By making all `core`, `contrib`, `web`, and `node` libraries use this tool, in the future we can use GitHub's API to produce a single file that lists all the changes made in an ecosystem update (e.g. v0.15.x release).

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
