### PR TITLE
Migrate FFI to ES modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,11 @@
 {
   "parserOptions": {
-    "ecmaVersion": 5
+    "ecmaVersion": 6,
+    "sourceType": "module"
   },
   "extends": "eslint:recommended",
   "env": {
-    "commonjs": true
+    "es6": true
   },
   "rules": {
     "strict": [2, "global"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,9 +4,6 @@
     "sourceType": "module"
   },
   "extends": "eslint:recommended",
-  "env": {
-    "es6": true
-  },
   "rules": {
     "strict": [2, "global"],
     "block-scoped-var": 2,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,16 +1,23 @@
 {
   "parserOptions": {
-    "ecmaVersion": 5
+    "ecmaVersion": 6,
+    "sourceType": "module"
   },
   "extends": "eslint:recommended",
   "env": {
-    "commonjs": true
+    "es6": true
   },
   "rules": {
-    "strict": [2, "global"],
+    "strict": [
+      2,
+      "global"
+    ],
     "block-scoped-var": 2,
     "consistent-return": 2,
-    "eqeqeq": [2, "smart"],
+    "eqeqeq": [
+      2,
+      "smart"
+    ],
     "guard-for-in": 2,
     "no-caller": 2,
     "no-extend-native": 2,
@@ -20,9 +27,24 @@
     "no-return-assign": 2,
     "no-unused-expressions": 2,
     "no-use-before-define": 2,
-    "radix": [2, "always"],
-    "indent": [2, 2, { "SwitchCase": 1 }],
-    "quotes": [2, "double"],
-    "semi": [2, "always"]
+    "radix": [
+      2,
+      "always"
+    ],
+    "indent": [
+      2,
+      2,
+      {
+        "SwitchCase": 1
+      }
+    ],
+    "quotes": [
+      2,
+      "double"
+    ],
+    "semi": [
+      2,
+      "always"
+    ]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,16 +8,10 @@
     "es6": true
   },
   "rules": {
-    "strict": [
-      2,
-      "global"
-    ],
+    "strict": [2, "global"],
     "block-scoped-var": 2,
     "consistent-return": 2,
-    "eqeqeq": [
-      2,
-      "smart"
-    ],
+    "eqeqeq": [2, "smart"],
     "guard-for-in": 2,
     "no-caller": 2,
     "no-extend-native": 2,
@@ -27,24 +21,9 @@
     "no-return-assign": 2,
     "no-unused-expressions": 2,
     "no-use-before-define": 2,
-    "radix": [
-      2,
-      "always"
-    ],
-    "indent": [
-      2,
-      2,
-      {
-        "SwitchCase": 1
-      }
-    ],
-    "quotes": [
-      2,
-      "double"
-    ],
-    "semi": [
-      2,
-      "always"
-    ]
+    "radix": [2, "always"],
+    "indent": [2, 2, { "SwitchCase": 1 }],
+    "quotes": [2, "double"],
+    "semi": [2, "always"]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,10 @@
 {
   "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module"
+    "ecmaVersion": 5
   },
   "extends": "eslint:recommended",
   "env": {
-    "es6": true
+    "commonjs": true
   },
   "rules": {
     "strict": [2, "global"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: "0.15.0-alpha-01"
+          purescript: "unstable"
 
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: purescript-contrib/setup-purescript@main
+        with:
+          purescript: "0.15.0-alpha-01"
 
       - uses: actions/setup-node@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+- Migrated FFI to ES Modules (#287 by @kl0tl and @JordanMartinez)
 
 New features:
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "eslint": "^7.15.0",
     "purescript-psa": "^0.8.0",
-    "pulp": "^15.0.0",
+    "pulp": "16.0.0-0",
     "rimraf": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "eslint": "^7.15.0",
-    "purescript-psa": "^0.8.0",
+    "purescript-psa": "^0.8.2",
     "pulp": "16.0.0-0",
     "rimraf": "^3.0.2"
   }

--- a/src/Control/Apply.js
+++ b/src/Control/Apply.js
@@ -1,5 +1,3 @@
-
-
 export const arrayApply = function (fs) {
   return function (xs) {
     var l = fs.length;

--- a/src/Control/Apply.js
+++ b/src/Control/Apply.js
@@ -1,4 +1,4 @@
-export const arrayApply = function (fs) {
+export var arrayApply = function (fs) {
   return function (xs) {
     var l = fs.length;
     var k = xs.length;

--- a/src/Control/Apply.js
+++ b/src/Control/Apply.js
@@ -1,4 +1,4 @@
-export var arrayApply = function (fs) {
+export const arrayApply = function (fs) {
   return function (xs) {
     var l = fs.length;
     var k = xs.length;

--- a/src/Control/Apply.js
+++ b/src/Control/Apply.js
@@ -1,6 +1,6 @@
-"use strict";
 
-export var arrayApply = function (fs) {
+
+export const arrayApply = function (fs) {
   return function (xs) {
     var l = fs.length;
     var k = xs.length;

--- a/src/Control/Apply.js
+++ b/src/Control/Apply.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.arrayApply = function (fs) {
+export var arrayApply = function (fs) {
   return function (xs) {
     var l = fs.length;
     var k = xs.length;

--- a/src/Control/Bind.js
+++ b/src/Control/Bind.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.arrayBind = function (arr) {
+export var arrayBind = function (arr) {
   return function (f) {
     var result = [];
     for (var i = 0, l = arr.length; i < l; i++) {

--- a/src/Control/Bind.js
+++ b/src/Control/Bind.js
@@ -1,4 +1,4 @@
-export var arrayBind = function (arr) {
+export const arrayBind = function (arr) {
   return function (f) {
     var result = [];
     for (var i = 0, l = arr.length; i < l; i++) {

--- a/src/Control/Bind.js
+++ b/src/Control/Bind.js
@@ -1,6 +1,6 @@
-"use strict";
 
-export var arrayBind = function (arr) {
+
+export const arrayBind = function (arr) {
   return function (f) {
     var result = [];
     for (var i = 0, l = arr.length; i < l; i++) {

--- a/src/Control/Bind.js
+++ b/src/Control/Bind.js
@@ -1,4 +1,4 @@
-export const arrayBind = function (arr) {
+export var arrayBind = function (arr) {
   return function (f) {
     var result = [];
     for (var i = 0, l = arr.length; i < l; i++) {

--- a/src/Control/Bind.js
+++ b/src/Control/Bind.js
@@ -1,5 +1,3 @@
-
-
 export const arrayBind = function (arr) {
   return function (f) {
     var result = [];

--- a/src/Data/Bounded.js
+++ b/src/Data/Bounded.js
@@ -1,10 +1,10 @@
-"use strict";
 
-export var topInt = 2147483647;
-export var bottomInt = -2147483648;
 
-export var topChar = String.fromCharCode(65535);
-export var bottomChar = String.fromCharCode(0);
+export const topInt = 2147483647;
+export const bottomInt = -2147483648;
 
-export var topNumber = Number.POSITIVE_INFINITY;
-export var bottomNumber = Number.NEGATIVE_INFINITY;
+export const topChar = String.fromCharCode(65535);
+export const bottomChar = String.fromCharCode(0);
+
+export const topNumber = Number.POSITIVE_INFINITY;
+export const bottomNumber = Number.NEGATIVE_INFINITY;

--- a/src/Data/Bounded.js
+++ b/src/Data/Bounded.js
@@ -1,10 +1,10 @@
 "use strict";
 
-exports.topInt = 2147483647;
-exports.bottomInt = -2147483648;
+export var topInt = 2147483647;
+export var bottomInt = -2147483648;
 
-exports.topChar = String.fromCharCode(65535);
-exports.bottomChar = String.fromCharCode(0);
+export var topChar = String.fromCharCode(65535);
+export var bottomChar = String.fromCharCode(0);
 
-exports.topNumber = Number.POSITIVE_INFINITY;
-exports.bottomNumber = Number.NEGATIVE_INFINITY;
+export var topNumber = Number.POSITIVE_INFINITY;
+export var bottomNumber = Number.NEGATIVE_INFINITY;

--- a/src/Data/Bounded.js
+++ b/src/Data/Bounded.js
@@ -1,5 +1,3 @@
-
-
 export const topInt = 2147483647;
 export const bottomInt = -2147483648;
 

--- a/src/Data/Eq.js
+++ b/src/Data/Eq.js
@@ -1,4 +1,4 @@
-"use strict";
+
 
 var refEq = function (r1) {
   return function (r2) {
@@ -6,13 +6,13 @@ var refEq = function (r1) {
   };
 };
 
-export var eqBooleanImpl = refEq;
-export var eqIntImpl = refEq;
-export var eqNumberImpl = refEq;
-export var eqCharImpl = refEq;
-export var eqStringImpl = refEq;
+export const eqBooleanImpl = refEq;
+export const eqIntImpl = refEq;
+export const eqNumberImpl = refEq;
+export const eqCharImpl = refEq;
+export const eqStringImpl = refEq;
 
-export var eqArrayImpl = function (f) {
+export const eqArrayImpl = function (f) {
   return function (xs) {
     return function (ys) {
       if (xs.length !== ys.length) return false;

--- a/src/Data/Eq.js
+++ b/src/Data/Eq.js
@@ -1,5 +1,3 @@
-
-
 var refEq = function (r1) {
   return function (r2) {
     return r1 === r2;

--- a/src/Data/Eq.js
+++ b/src/Data/Eq.js
@@ -6,13 +6,13 @@ var refEq = function (r1) {
   };
 };
 
-exports.eqBooleanImpl = refEq;
-exports.eqIntImpl = refEq;
-exports.eqNumberImpl = refEq;
-exports.eqCharImpl = refEq;
-exports.eqStringImpl = refEq;
+export var eqBooleanImpl = refEq;
+export var eqIntImpl = refEq;
+export var eqNumberImpl = refEq;
+export var eqCharImpl = refEq;
+export var eqStringImpl = refEq;
 
-exports.eqArrayImpl = function (f) {
+export var eqArrayImpl = function (f) {
   return function (xs) {
     return function (ys) {
       if (xs.length !== ys.length) return false;

--- a/src/Data/EuclideanRing.js
+++ b/src/Data/EuclideanRing.js
@@ -1,17 +1,17 @@
-export var intDegree = function (x) {
+export const intDegree = function (x) {
   return Math.min(Math.abs(x), 2147483647);
 };
 
 // See the Euclidean definition in
 // https://en.m.wikipedia.org/wiki/Modulo_operation.
-export var intDiv = function (x) {
+export const intDiv = function (x) {
   return function (y) {
     if (y === 0) return 0;
     return y > 0 ? Math.floor(x / y) : -Math.floor(x / -y);
   };
 };
 
-export var intMod = function (x) {
+export const intMod = function (x) {
   return function (y) {
     if (y === 0) return 0;
     var yy = Math.abs(y);
@@ -19,7 +19,7 @@ export var intMod = function (x) {
   };
 };
 
-export var numDiv = function (n1) {
+export const numDiv = function (n1) {
   return function (n2) {
     return n1 / n2;
   };

--- a/src/Data/EuclideanRing.js
+++ b/src/Data/EuclideanRing.js
@@ -1,19 +1,19 @@
 "use strict";
 
-exports.intDegree = function (x) {
+export var intDegree = function (x) {
   return Math.min(Math.abs(x), 2147483647);
 };
 
 // See the Euclidean definition in
 // https://en.m.wikipedia.org/wiki/Modulo_operation.
-exports.intDiv = function (x) {
+export var intDiv = function (x) {
   return function (y) {
     if (y === 0) return 0;
     return y > 0 ? Math.floor(x / y) : -Math.floor(x / -y);
   };
 };
 
-exports.intMod = function (x) {
+export var intMod = function (x) {
   return function (y) {
     if (y === 0) return 0;
     var yy = Math.abs(y);
@@ -21,7 +21,7 @@ exports.intMod = function (x) {
   };
 };
 
-exports.numDiv = function (n1) {
+export var numDiv = function (n1) {
   return function (n2) {
     return n1 / n2;
   };

--- a/src/Data/EuclideanRing.js
+++ b/src/Data/EuclideanRing.js
@@ -1,17 +1,17 @@
-export const intDegree = function (x) {
+export var intDegree = function (x) {
   return Math.min(Math.abs(x), 2147483647);
 };
 
 // See the Euclidean definition in
 // https://en.m.wikipedia.org/wiki/Modulo_operation.
-export const intDiv = function (x) {
+export var intDiv = function (x) {
   return function (y) {
     if (y === 0) return 0;
     return y > 0 ? Math.floor(x / y) : -Math.floor(x / -y);
   };
 };
 
-export const intMod = function (x) {
+export var intMod = function (x) {
   return function (y) {
     if (y === 0) return 0;
     var yy = Math.abs(y);
@@ -19,7 +19,7 @@ export const intMod = function (x) {
   };
 };
 
-export const numDiv = function (n1) {
+export var numDiv = function (n1) {
   return function (n2) {
     return n1 / n2;
   };

--- a/src/Data/EuclideanRing.js
+++ b/src/Data/EuclideanRing.js
@@ -1,19 +1,19 @@
-"use strict";
 
-export var intDegree = function (x) {
+
+export const intDegree = function (x) {
   return Math.min(Math.abs(x), 2147483647);
 };
 
 // See the Euclidean definition in
 // https://en.m.wikipedia.org/wiki/Modulo_operation.
-export var intDiv = function (x) {
+export const intDiv = function (x) {
   return function (y) {
     if (y === 0) return 0;
     return y > 0 ? Math.floor(x / y) : -Math.floor(x / -y);
   };
 };
 
-export var intMod = function (x) {
+export const intMod = function (x) {
   return function (y) {
     if (y === 0) return 0;
     var yy = Math.abs(y);
@@ -21,7 +21,7 @@ export var intMod = function (x) {
   };
 };
 
-export var numDiv = function (n1) {
+export const numDiv = function (n1) {
   return function (n2) {
     return n1 / n2;
   };

--- a/src/Data/EuclideanRing.js
+++ b/src/Data/EuclideanRing.js
@@ -1,5 +1,3 @@
-
-
 export const intDegree = function (x) {
   return Math.min(Math.abs(x), 2147483647);
 };

--- a/src/Data/Functor.js
+++ b/src/Data/Functor.js
@@ -1,6 +1,6 @@
-"use strict";
 
-export var arrayMap = function (f) {
+
+export const arrayMap = function (f) {
   return function (arr) {
     var l = arr.length;
     var result = new Array(l);

--- a/src/Data/Functor.js
+++ b/src/Data/Functor.js
@@ -1,4 +1,4 @@
-export var arrayMap = function (f) {
+export const arrayMap = function (f) {
   return function (arr) {
     var l = arr.length;
     var result = new Array(l);

--- a/src/Data/Functor.js
+++ b/src/Data/Functor.js
@@ -1,5 +1,3 @@
-
-
 export const arrayMap = function (f) {
   return function (arr) {
     var l = arr.length;

--- a/src/Data/Functor.js
+++ b/src/Data/Functor.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.arrayMap = function (f) {
+export var arrayMap = function (f) {
   return function (arr) {
     var l = arr.length;
     var result = new Array(l);

--- a/src/Data/Functor.js
+++ b/src/Data/Functor.js
@@ -1,4 +1,4 @@
-export const arrayMap = function (f) {
+export var arrayMap = function (f) {
   return function (arr) {
     var l = arr.length;
     var result = new Array(l);

--- a/src/Data/HeytingAlgebra.js
+++ b/src/Data/HeytingAlgebra.js
@@ -1,17 +1,17 @@
-"use strict";
 
-export var boolConj = function (b1) {
+
+export const boolConj = function (b1) {
   return function (b2) {
     return b1 && b2;
   };
 };
 
-export var boolDisj = function (b1) {
+export const boolDisj = function (b1) {
   return function (b2) {
     return b1 || b2;
   };
 };
 
-export var boolNot = function (b) {
+export const boolNot = function (b) {
   return !b;
 };

--- a/src/Data/HeytingAlgebra.js
+++ b/src/Data/HeytingAlgebra.js
@@ -1,15 +1,15 @@
-export const boolConj = function (b1) {
+export var boolConj = function (b1) {
   return function (b2) {
     return b1 && b2;
   };
 };
 
-export const boolDisj = function (b1) {
+export var boolDisj = function (b1) {
   return function (b2) {
     return b1 || b2;
   };
 };
 
-export const boolNot = function (b) {
+export var boolNot = function (b) {
   return !b;
 };

--- a/src/Data/HeytingAlgebra.js
+++ b/src/Data/HeytingAlgebra.js
@@ -1,5 +1,3 @@
-
-
 export const boolConj = function (b1) {
   return function (b2) {
     return b1 && b2;

--- a/src/Data/HeytingAlgebra.js
+++ b/src/Data/HeytingAlgebra.js
@@ -1,17 +1,17 @@
 "use strict";
 
-exports.boolConj = function (b1) {
+export var boolConj = function (b1) {
   return function (b2) {
     return b1 && b2;
   };
 };
 
-exports.boolDisj = function (b1) {
+export var boolDisj = function (b1) {
   return function (b2) {
     return b1 || b2;
   };
 };
 
-exports.boolNot = function (b) {
+export var boolNot = function (b) {
   return !b;
 };

--- a/src/Data/HeytingAlgebra.js
+++ b/src/Data/HeytingAlgebra.js
@@ -1,15 +1,15 @@
-export var boolConj = function (b1) {
+export const boolConj = function (b1) {
   return function (b2) {
     return b1 && b2;
   };
 };
 
-export var boolDisj = function (b1) {
+export const boolDisj = function (b1) {
   return function (b2) {
     return b1 || b2;
   };
 };
 
-export var boolNot = function (b) {
+export const boolNot = function (b) {
   return !b;
 };

--- a/src/Data/Ord.js
+++ b/src/Data/Ord.js
@@ -1,4 +1,4 @@
-"use strict";
+
 
 var unsafeCompareImpl = function (lt) {
   return function (eq) {
@@ -12,13 +12,13 @@ var unsafeCompareImpl = function (lt) {
   };
 };
 
-export var ordBooleanImpl = unsafeCompareImpl;
-export var ordIntImpl = unsafeCompareImpl;
-export var ordNumberImpl = unsafeCompareImpl;
-export var ordStringImpl = unsafeCompareImpl;
-export var ordCharImpl = unsafeCompareImpl;
+export const ordBooleanImpl = unsafeCompareImpl;
+export const ordIntImpl = unsafeCompareImpl;
+export const ordNumberImpl = unsafeCompareImpl;
+export const ordStringImpl = unsafeCompareImpl;
+export const ordCharImpl = unsafeCompareImpl;
 
-export var ordArrayImpl = function (f) {
+export const ordArrayImpl = function (f) {
   return function (xs) {
     return function (ys) {
       var i = 0;

--- a/src/Data/Ord.js
+++ b/src/Data/Ord.js
@@ -1,5 +1,3 @@
-
-
 var unsafeCompareImpl = function (lt) {
   return function (eq) {
     return function (gt) {

--- a/src/Data/Ord.js
+++ b/src/Data/Ord.js
@@ -12,13 +12,13 @@ var unsafeCompareImpl = function (lt) {
   };
 };
 
-exports.ordBooleanImpl = unsafeCompareImpl;
-exports.ordIntImpl = unsafeCompareImpl;
-exports.ordNumberImpl = unsafeCompareImpl;
-exports.ordStringImpl = unsafeCompareImpl;
-exports.ordCharImpl = unsafeCompareImpl;
+export var ordBooleanImpl = unsafeCompareImpl;
+export var ordIntImpl = unsafeCompareImpl;
+export var ordNumberImpl = unsafeCompareImpl;
+export var ordStringImpl = unsafeCompareImpl;
+export var ordCharImpl = unsafeCompareImpl;
 
-exports.ordArrayImpl = function (f) {
+export var ordArrayImpl = function (f) {
   return function (xs) {
     return function (ys) {
       var i = 0;

--- a/src/Data/Ring.js
+++ b/src/Data/Ring.js
@@ -1,11 +1,11 @@
-export const intSub = function (x) {
+export var intSub = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x - y | 0;
   };
 };
 
-export const numSub = function (n1) {
+export var numSub = function (n1) {
   return function (n2) {
     return n1 - n2;
   };

--- a/src/Data/Ring.js
+++ b/src/Data/Ring.js
@@ -1,5 +1,3 @@
-
-
 export const intSub = function (x) {
   return function (y) {
     /* jshint bitwise: false */

--- a/src/Data/Ring.js
+++ b/src/Data/Ring.js
@@ -1,13 +1,13 @@
 "use strict";
 
-exports.intSub = function (x) {
+export var intSub = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x - y | 0;
   };
 };
 
-exports.numSub = function (n1) {
+export var numSub = function (n1) {
   return function (n2) {
     return n1 - n2;
   };

--- a/src/Data/Ring.js
+++ b/src/Data/Ring.js
@@ -1,11 +1,11 @@
-export var intSub = function (x) {
+export const intSub = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x - y | 0;
   };
 };
 
-export var numSub = function (n1) {
+export const numSub = function (n1) {
   return function (n2) {
     return n1 - n2;
   };

--- a/src/Data/Ring.js
+++ b/src/Data/Ring.js
@@ -1,13 +1,13 @@
-"use strict";
 
-export var intSub = function (x) {
+
+export const intSub = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x - y | 0;
   };
 };
 
-export var numSub = function (n1) {
+export const numSub = function (n1) {
   return function (n2) {
     return n1 - n2;
   };

--- a/src/Data/Semigroup.js
+++ b/src/Data/Semigroup.js
@@ -1,5 +1,3 @@
-
-
 export const concatString = function (s1) {
   return function (s2) {
     return s1 + s2;

--- a/src/Data/Semigroup.js
+++ b/src/Data/Semigroup.js
@@ -1,10 +1,10 @@
-export var concatString = function (s1) {
+export const concatString = function (s1) {
   return function (s2) {
     return s1 + s2;
   };
 };
 
-export var concatArray = function (xs) {
+export const concatArray = function (xs) {
   return function (ys) {
     if (xs.length === 0) return ys;
     if (ys.length === 0) return xs;

--- a/src/Data/Semigroup.js
+++ b/src/Data/Semigroup.js
@@ -1,12 +1,12 @@
-"use strict";
 
-export var concatString = function (s1) {
+
+export const concatString = function (s1) {
   return function (s2) {
     return s1 + s2;
   };
 };
 
-export var concatArray = function (xs) {
+export const concatArray = function (xs) {
   return function (ys) {
     if (xs.length === 0) return ys;
     if (ys.length === 0) return xs;

--- a/src/Data/Semigroup.js
+++ b/src/Data/Semigroup.js
@@ -1,10 +1,10 @@
-export const concatString = function (s1) {
+export var concatString = function (s1) {
   return function (s2) {
     return s1 + s2;
   };
 };
 
-export const concatArray = function (xs) {
+export var concatArray = function (xs) {
   return function (ys) {
     if (xs.length === 0) return ys;
     if (ys.length === 0) return xs;

--- a/src/Data/Semigroup.js
+++ b/src/Data/Semigroup.js
@@ -1,12 +1,12 @@
 "use strict";
 
-exports.concatString = function (s1) {
+export var concatString = function (s1) {
   return function (s2) {
     return s1 + s2;
   };
 };
 
-exports.concatArray = function (xs) {
+export var concatArray = function (xs) {
   return function (ys) {
     if (xs.length === 0) return ys;
     if (ys.length === 0) return xs;

--- a/src/Data/Semiring.js
+++ b/src/Data/Semiring.js
@@ -1,24 +1,24 @@
-export const intAdd = function (x) {
+export var intAdd = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x + y | 0;
   };
 };
 
-export const intMul = function (x) {
+export var intMul = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x * y | 0;
   };
 };
 
-export const numAdd = function (n1) {
+export var numAdd = function (n1) {
   return function (n2) {
     return n1 + n2;
   };
 };
 
-export const numMul = function (n1) {
+export var numMul = function (n1) {
   return function (n2) {
     return n1 * n2;
   };

--- a/src/Data/Semiring.js
+++ b/src/Data/Semiring.js
@@ -1,5 +1,3 @@
-
-
 export const intAdd = function (x) {
   return function (y) {
     /* jshint bitwise: false */

--- a/src/Data/Semiring.js
+++ b/src/Data/Semiring.js
@@ -1,26 +1,26 @@
-"use strict";
 
-export var intAdd = function (x) {
+
+export const intAdd = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x + y | 0;
   };
 };
 
-export var intMul = function (x) {
+export const intMul = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x * y | 0;
   };
 };
 
-export var numAdd = function (n1) {
+export const numAdd = function (n1) {
   return function (n2) {
     return n1 + n2;
   };
 };
 
-export var numMul = function (n1) {
+export const numMul = function (n1) {
   return function (n2) {
     return n1 * n2;
   };

--- a/src/Data/Semiring.js
+++ b/src/Data/Semiring.js
@@ -1,26 +1,26 @@
 "use strict";
 
-exports.intAdd = function (x) {
+export var intAdd = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x + y | 0;
   };
 };
 
-exports.intMul = function (x) {
+export var intMul = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x * y | 0;
   };
 };
 
-exports.numAdd = function (n1) {
+export var numAdd = function (n1) {
   return function (n2) {
     return n1 + n2;
   };
 };
 
-exports.numMul = function (n1) {
+export var numMul = function (n1) {
   return function (n2) {
     return n1 * n2;
   };

--- a/src/Data/Semiring.js
+++ b/src/Data/Semiring.js
@@ -1,24 +1,24 @@
-export var intAdd = function (x) {
+export const intAdd = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x + y | 0;
   };
 };
 
-export var intMul = function (x) {
+export const intMul = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x * y | 0;
   };
 };
 
-export var numAdd = function (n1) {
+export const numAdd = function (n1) {
   return function (n2) {
     return n1 + n2;
   };
 };
 
-export var numMul = function (n1) {
+export const numMul = function (n1) {
   return function (n2) {
     return n1 * n2;
   };

--- a/src/Data/Show.js
+++ b/src/Data/Show.js
@@ -1,13 +1,13 @@
-export const showIntImpl = function (n) {
+export var showIntImpl = function (n) {
   return n.toString();
 };
 
-export const showNumberImpl = function (n) {
+export var showNumberImpl = function (n) {
   var str = n.toString();
   return isNaN(str + ".0") ? str : str + ".0";
 };
 
-export const showCharImpl = function (c) {
+export var showCharImpl = function (c) {
   var code = c.charCodeAt(0);
   if (code < 0x20 || code === 0x7F) {
     switch (c) {
@@ -24,7 +24,7 @@ export const showCharImpl = function (c) {
   return c === "'" || c === "\\" ? "'\\" + c + "'" : "'" + c + "'";
 };
 
-export const showStringImpl = function (s) {
+export var showStringImpl = function (s) {
   var l = s.length;
   return "\"" + s.replace(
     /[\0-\x1F\x7F"\\]/g, // eslint-disable-line no-control-regex
@@ -48,7 +48,7 @@ export const showStringImpl = function (s) {
   ) + "\"";
 };
 
-export const showArrayImpl = function (f) {
+export var showArrayImpl = function (f) {
   return function (xs) {
     var ss = [];
     for (var i = 0, l = xs.length; i < l; i++) {
@@ -58,13 +58,13 @@ export const showArrayImpl = function (f) {
   };
 };
 
-export const cons = function (head) {
+export var cons = function (head) {
   return function (tail) {
     return [head].concat(tail);
   };
 };
 
-export const join = function (separator) {
+export var join = function (separator) {
   return function (xs) {
     return xs.join(separator);
   };

--- a/src/Data/Show.js
+++ b/src/Data/Show.js
@@ -1,5 +1,3 @@
-
-
 export const showIntImpl = function (n) {
   return n.toString();
 };

--- a/src/Data/Show.js
+++ b/src/Data/Show.js
@@ -1,13 +1,13 @@
-export var showIntImpl = function (n) {
+export const showIntImpl = function (n) {
   return n.toString();
 };
 
-export var showNumberImpl = function (n) {
+export const showNumberImpl = function (n) {
   var str = n.toString();
   return isNaN(str + ".0") ? str : str + ".0";
 };
 
-export var showCharImpl = function (c) {
+export const showCharImpl = function (c) {
   var code = c.charCodeAt(0);
   if (code < 0x20 || code === 0x7F) {
     switch (c) {
@@ -24,7 +24,7 @@ export var showCharImpl = function (c) {
   return c === "'" || c === "\\" ? "'\\" + c + "'" : "'" + c + "'";
 };
 
-export var showStringImpl = function (s) {
+export const showStringImpl = function (s) {
   var l = s.length;
   return "\"" + s.replace(
     /[\0-\x1F\x7F"\\]/g, // eslint-disable-line no-control-regex
@@ -48,7 +48,7 @@ export var showStringImpl = function (s) {
   ) + "\"";
 };
 
-export var showArrayImpl = function (f) {
+export const showArrayImpl = function (f) {
   return function (xs) {
     var ss = [];
     for (var i = 0, l = xs.length; i < l; i++) {
@@ -58,13 +58,13 @@ export var showArrayImpl = function (f) {
   };
 };
 
-export var cons = function (head) {
+export const cons = function (head) {
   return function (tail) {
     return [head].concat(tail);
   };
 };
 
-export var join = function (separator) {
+export const join = function (separator) {
   return function (xs) {
     return xs.join(separator);
   };

--- a/src/Data/Show.js
+++ b/src/Data/Show.js
@@ -1,15 +1,15 @@
 "use strict";
 
-exports.showIntImpl = function (n) {
+export var showIntImpl = function (n) {
   return n.toString();
 };
 
-exports.showNumberImpl = function (n) {
+export var showNumberImpl = function (n) {
   var str = n.toString();
   return isNaN(str + ".0") ? str : str + ".0";
 };
 
-exports.showCharImpl = function (c) {
+export var showCharImpl = function (c) {
   var code = c.charCodeAt(0);
   if (code < 0x20 || code === 0x7F) {
     switch (c) {
@@ -26,7 +26,7 @@ exports.showCharImpl = function (c) {
   return c === "'" || c === "\\" ? "'\\" + c + "'" : "'" + c + "'";
 };
 
-exports.showStringImpl = function (s) {
+export var showStringImpl = function (s) {
   var l = s.length;
   return "\"" + s.replace(
     /[\0-\x1F\x7F"\\]/g, // eslint-disable-line no-control-regex
@@ -50,7 +50,7 @@ exports.showStringImpl = function (s) {
   ) + "\"";
 };
 
-exports.showArrayImpl = function (f) {
+export var showArrayImpl = function (f) {
   return function (xs) {
     var ss = [];
     for (var i = 0, l = xs.length; i < l; i++) {
@@ -60,13 +60,13 @@ exports.showArrayImpl = function (f) {
   };
 };
 
-exports.cons = function (head) {
+export var cons = function (head) {
   return function (tail) {
     return [head].concat(tail);
   };
 };
 
-exports.join = function (separator) {
+export var join = function (separator) {
   return function (xs) {
     return xs.join(separator);
   };

--- a/src/Data/Show.js
+++ b/src/Data/Show.js
@@ -1,15 +1,15 @@
-"use strict";
 
-export var showIntImpl = function (n) {
+
+export const showIntImpl = function (n) {
   return n.toString();
 };
 
-export var showNumberImpl = function (n) {
+export const showNumberImpl = function (n) {
   var str = n.toString();
   return isNaN(str + ".0") ? str : str + ".0";
 };
 
-export var showCharImpl = function (c) {
+export const showCharImpl = function (c) {
   var code = c.charCodeAt(0);
   if (code < 0x20 || code === 0x7F) {
     switch (c) {
@@ -26,7 +26,7 @@ export var showCharImpl = function (c) {
   return c === "'" || c === "\\" ? "'\\" + c + "'" : "'" + c + "'";
 };
 
-export var showStringImpl = function (s) {
+export const showStringImpl = function (s) {
   var l = s.length;
   return "\"" + s.replace(
     /[\0-\x1F\x7F"\\]/g, // eslint-disable-line no-control-regex
@@ -50,7 +50,7 @@ export var showStringImpl = function (s) {
   ) + "\"";
 };
 
-export var showArrayImpl = function (f) {
+export const showArrayImpl = function (f) {
   return function (xs) {
     var ss = [];
     for (var i = 0, l = xs.length; i < l; i++) {
@@ -60,13 +60,13 @@ export var showArrayImpl = function (f) {
   };
 };
 
-export var cons = function (head) {
+export const cons = function (head) {
   return function (tail) {
     return [head].concat(tail);
   };
 };
 
-export var join = function (separator) {
+export const join = function (separator) {
   return function (xs) {
     return xs.join(separator);
   };

--- a/src/Data/Show/Generic.js
+++ b/src/Data/Show/Generic.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.intercalate = function (separator) {
+export var intercalate = function (separator) {
   return function (xs) {
     var len = xs.length;
     if (len === 0) return "";

--- a/src/Data/Show/Generic.js
+++ b/src/Data/Show/Generic.js
@@ -1,6 +1,6 @@
-"use strict";
 
-export var intercalate = function (separator) {
+
+export const intercalate = function (separator) {
   return function (xs) {
     var len = xs.length;
     if (len === 0) return "";

--- a/src/Data/Show/Generic.js
+++ b/src/Data/Show/Generic.js
@@ -1,4 +1,4 @@
-export const intercalate = function (separator) {
+export var intercalate = function (separator) {
   return function (xs) {
     var len = xs.length;
     if (len === 0) return "";

--- a/src/Data/Show/Generic.js
+++ b/src/Data/Show/Generic.js
@@ -1,5 +1,3 @@
-
-
 export const intercalate = function (separator) {
   return function (xs) {
     var len = xs.length;

--- a/src/Data/Show/Generic.js
+++ b/src/Data/Show/Generic.js
@@ -1,4 +1,4 @@
-export var intercalate = function (separator) {
+export const intercalate = function (separator) {
   return function (xs) {
     var len = xs.length;
     if (len === 0) return "";

--- a/src/Data/Symbol.js
+++ b/src/Data/Symbol.js
@@ -1,8 +1,8 @@
-"use strict";
+
 
 // module Data.Symbol
 
-export var unsafeCoerce = function (arg) {
+export const unsafeCoerce = function (arg) {
   return arg;
 };
 

--- a/src/Data/Symbol.js
+++ b/src/Data/Symbol.js
@@ -1,5 +1,3 @@
-
-
 // module Data.Symbol
 
 export const unsafeCoerce = function (arg) {

--- a/src/Data/Symbol.js
+++ b/src/Data/Symbol.js
@@ -2,7 +2,7 @@
 
 // module Data.Symbol
 
-exports.unsafeCoerce = function (arg) {
+export var unsafeCoerce = function (arg) {
   return arg;
 };
 

--- a/src/Data/Unit.js
+++ b/src/Data/Unit.js
@@ -1,1 +1,1 @@
-exports.unit = undefined;
+export const unit = undefined;

--- a/src/Data/Unit.js
+++ b/src/Data/Unit.js
@@ -1,3 +1,3 @@
-"use strict";
 
-export var unit = {};
+
+export const unit = {};

--- a/src/Data/Unit.js
+++ b/src/Data/Unit.js
@@ -1,3 +1,3 @@
 "use strict";
 
-exports.unit = {};
+export var unit = {};

--- a/src/Record/Unsafe.js
+++ b/src/Record/Unsafe.js
@@ -1,5 +1,3 @@
-
-
 export const unsafeHas = function (label) {
   return function (rec) {
     return {}.hasOwnProperty.call(rec, label);

--- a/src/Record/Unsafe.js
+++ b/src/Record/Unsafe.js
@@ -1,18 +1,18 @@
 "use strict";
 
-exports.unsafeHas = function (label) {
+export var unsafeHas = function (label) {
   return function (rec) {
     return {}.hasOwnProperty.call(rec, label);
   };
 };
 
-exports.unsafeGet = function (label) {
+export var unsafeGet = function (label) {
   return function (rec) {
     return rec[label];
   };
 };
 
-exports.unsafeSet = function (label) {
+export var unsafeSet = function (label) {
   return function (value) {
     return function (rec) {
       var copy = {};
@@ -27,7 +27,7 @@ exports.unsafeSet = function (label) {
   };
 };
 
-exports.unsafeDelete = function (label) {
+export var unsafeDelete = function (label) {
   return function (rec) {
     var copy = {};
     for (var key in rec) {

--- a/src/Record/Unsafe.js
+++ b/src/Record/Unsafe.js
@@ -1,18 +1,18 @@
-"use strict";
 
-export var unsafeHas = function (label) {
+
+export const unsafeHas = function (label) {
   return function (rec) {
     return {}.hasOwnProperty.call(rec, label);
   };
 };
 
-export var unsafeGet = function (label) {
+export const unsafeGet = function (label) {
   return function (rec) {
     return rec[label];
   };
 };
 
-export var unsafeSet = function (label) {
+export const unsafeSet = function (label) {
   return function (value) {
     return function (rec) {
       var copy = {};
@@ -27,7 +27,7 @@ export var unsafeSet = function (label) {
   };
 };
 
-export var unsafeDelete = function (label) {
+export const unsafeDelete = function (label) {
   return function (rec) {
     var copy = {};
     for (var key in rec) {

--- a/src/Record/Unsafe.js
+++ b/src/Record/Unsafe.js
@@ -1,16 +1,16 @@
-export var unsafeHas = function (label) {
+export const unsafeHas = function (label) {
   return function (rec) {
     return {}.hasOwnProperty.call(rec, label);
   };
 };
 
-export var unsafeGet = function (label) {
+export const unsafeGet = function (label) {
   return function (rec) {
     return rec[label];
   };
 };
 
-export var unsafeSet = function (label) {
+export const unsafeSet = function (label) {
   return function (value) {
     return function (rec) {
       var copy = {};
@@ -25,7 +25,7 @@ export var unsafeSet = function (label) {
   };
 };
 
-export var unsafeDelete = function (label) {
+export const unsafeDelete = function (label) {
   return function (rec) {
     var copy = {};
     for (var key in rec) {

--- a/src/Record/Unsafe.js
+++ b/src/Record/Unsafe.js
@@ -1,16 +1,16 @@
-export const unsafeHas = function (label) {
+export var unsafeHas = function (label) {
   return function (rec) {
     return {}.hasOwnProperty.call(rec, label);
   };
 };
 
-export const unsafeGet = function (label) {
+export var unsafeGet = function (label) {
   return function (rec) {
     return rec[label];
   };
 };
 
-export const unsafeSet = function (label) {
+export var unsafeSet = function (label) {
   return function (value) {
     return function (rec) {
       var copy = {};
@@ -25,7 +25,7 @@ export const unsafeSet = function (label) {
   };
 };
 
-export const unsafeDelete = function (label) {
+export var unsafeDelete = function (label) {
   return function (rec) {
     var copy = {};
     for (var key in rec) {

--- a/test/Test/Main.js
+++ b/test/Test/Main.js
@@ -1,5 +1,3 @@
-
-
 export function testNumberShow(showNumber) {
   return function() {
     function testAll(cases) {

--- a/test/Test/Main.js
+++ b/test/Test/Main.js
@@ -1,6 +1,6 @@
-"use strict";
 
-exports.testNumberShow = function(showNumber) {
+
+export function testNumberShow(showNumber) {
   return function() {
     function testAll(cases) {
       cases.forEach(function(c) {
@@ -41,4 +41,4 @@ exports.testNumberShow = function(showNumber) {
         [-Infinity, "-Infinity"],
       ]);
   };
-};
+}

--- a/test/Test/Main.js
+++ b/test/Test/Main.js
@@ -16,29 +16,29 @@ export function testNumberShow(showNumber) {
     }
 
     testAll([
-        // Within Int range
-        [0.0, "0.0"],
-        [1.0, "1.0"],
-        [-1.0, "-1.0"],
-        [500.0, "500.0"],
+      // Within Int range
+      [0.0, "0.0"],
+      [1.0, "1.0"],
+      [-1.0, "-1.0"],
+      [500.0, "500.0"],
 
-        // Outside Int range
-        [1e10, "10000000000.0"],
-        [1e10 + 0.5, "10000000000.5"],
-        [-1e10, "-10000000000.0"],
-        [-1e10 - 0.5, "-10000000000.5"],
+      // Outside Int range
+      [1e10, "10000000000.0"],
+      [1e10 + 0.5, "10000000000.5"],
+      [-1e10, "-10000000000.0"],
+      [-1e10 - 0.5, "-10000000000.5"],
 
-        // With exponent
-        [1e21, "1e+21"],
-        [1e-21, "1e-21"],
+      // With exponent
+      [1e21, "1e+21"],
+      [1e-21, "1e-21"],
 
-        // With decimal and exponent
-        [1.5e21, "1.5e+21"],
-        [1.5e-10, "1.5e-10"],
+      // With decimal and exponent
+      [1.5e21, "1.5e+21"],
+      [1.5e-10, "1.5e-10"],
 
-        [NaN, "NaN"],
-        [Infinity, "Infinity"],
-        [-Infinity, "-Infinity"],
-      ]);
+      [NaN, "NaN"],
+      [Infinity, "Infinity"],
+      [-Infinity, "-Infinity"],
+    ]);
   };
 }

--- a/test/Test/Utils.js
+++ b/test/Test/Utils.js
@@ -1,5 +1,3 @@
-
-
 export function throwErr(msg) {
   return function() {
     throw new Error(msg);

--- a/test/Test/Utils.js
+++ b/test/Test/Utils.js
@@ -1,7 +1,7 @@
-"use strict";
 
-exports.throwErr = function(msg) {
+
+export function throwErr(msg) {
   return function() {
     throw new Error(msg);
   };
-};
+}


### PR DESCRIPTION
**Description of the change**

Backlinking to purescript/purescript#4244

Migrates FFI to ES modules. This continues what was started in #284 but using a different branch named `es-modules-libraries` to ensure further development on the compiler isn't affected by commits pushed to this PR. 

This PR also succeeds #264 since that PR was not opened by the 'working-group-purescript-es' org, which allows multiple people to push to the PR if the original submitter is gone for while.

This PR will fail to build until `pulp` has been updated to support ES modules when one calls `pulp run` and `pulp test`. See https://github.com/purescript-contrib/pulp/issues/400 for more info.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
