### PR TITLE
Implement Data.Reflectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
 - Replaced polymorphic proxies with monomorphic `Proxy` (#281, #288 by @JordanMartinez)
 
 New features:
+- Added the `Data.Reflectable` module for type reflection (#289 by @PureFunctor)
 
 Bugfixes:
 

--- a/src/Data/Reflectable.js
+++ b/src/Data/Reflectable.js
@@ -1,7 +1,5 @@
-"use strict";
-
 // module Data.Reflectable
 
-export function unsafeCoerce(arg) {
+export const unsafeCoerce = function (arg) {
   return arg;
-}
+};

--- a/src/Data/Reflectable.js
+++ b/src/Data/Reflectable.js
@@ -1,0 +1,7 @@
+"use strict";
+
+// module Data.Reflectable
+
+export function unsafeCoerce(arg) {
+  return arg;
+}

--- a/src/Data/Reflectable.purs
+++ b/src/Data/Reflectable.purs
@@ -1,0 +1,56 @@
+module Data.Reflectable
+  ( class Reflectable
+  , class Reifiable
+  , reflectType
+  , reifyType
+  ) where
+
+import Prim.Ordering (Ordering)
+import Type.Proxy (Proxy(..))
+
+-- | A type-class for reflectable types.
+-- |
+-- | Instances for the following kinds are solved by the compiler:
+-- | * Boolean
+-- | * Int
+-- | * Ordering
+-- | * Symbol
+class Reflectable :: forall k. k -> Type -> Constraint
+class Reflectable v t | v -> t where
+  -- | Reflect a type `v` to its term-level representation.
+  reflectType :: Proxy v -> t
+
+-- | A type class for reifiable types.
+-- |
+-- | Instances of this type class correspond to the `t` synthesized
+-- | by the compiler when solving the `Reflectable` type class.
+class Reifiable :: Type -> Constraint
+class Reifiable t
+
+instance Reifiable Boolean
+instance Reifiable Int
+instance Reifiable Ordering
+instance Reifiable String
+
+-- local definition for use in `reifyType`
+foreign import unsafeCoerce :: forall a b. a -> b
+
+-- | Reify a value of type `t` such that it can be consumed by a
+-- | function constrained by the `Reflectable` type class. For
+-- | example:
+-- |
+-- | ```hs
+-- | twiceFromType :: forall v. Reflectable v Int => Proxy v -> Int
+-- | twiceFromType = (_ * 2) <<< reflectType
+-- |
+-- | twiceOfTerm :: Int
+-- | twiceOfTerm = reifyType 21 twiceFromType
+-- | ```
+reifyType :: forall t r. Reifiable t => t -> (forall v. Reflectable v t => Proxy v -> r) -> r
+reifyType s f = coerce f { reflectType: \_ -> s } Proxy
+  where
+  coerce :: (forall v. Reflectable v t => Proxy v -> r)
+         -> { reflectType :: Proxy _ -> t }
+         -> Proxy _
+         -> r
+  coerce = unsafeCoerce

--- a/src/Data/Reflectable.purs
+++ b/src/Data/Reflectable.purs
@@ -5,7 +5,7 @@ module Data.Reflectable
   , reifyType
   ) where
 
-import Prim.Ordering (Ordering)
+import Data.Ord (Ordering)
 import Type.Proxy (Proxy(..))
 
 -- | A type-class for reflectable types.

--- a/src/Data/Reflectable.purs
+++ b/src/Data/Reflectable.purs
@@ -39,7 +39,7 @@ foreign import unsafeCoerce :: forall a b. a -> b
 -- | function constrained by the `Reflectable` type class. For
 -- | example:
 -- |
--- | ```hs
+-- | ```purs
 -- | twiceFromType :: forall v. Reflectable v Int => Proxy v -> Int
 -- | twiceFromType = (_ * 2) <<< reflectType
 -- |

--- a/src/Data/Reflectable.purs
+++ b/src/Data/Reflectable.purs
@@ -49,8 +49,9 @@ foreign import unsafeCoerce :: forall a b. a -> b
 reifyType :: forall t r. Reifiable t => t -> (forall v. Reflectable v t => Proxy v -> r) -> r
 reifyType s f = coerce f { reflectType: \_ -> s } Proxy
   where
-  coerce :: (forall v. Reflectable v t => Proxy v -> r)
-         -> { reflectType :: Proxy _ -> t }
-         -> Proxy _
-         -> r
+  coerce
+    :: (forall v. Reflectable v t => Proxy v -> r)
+    -> { reflectType :: Proxy _ -> t }
+    -> Proxy _
+    -> r
   coerce = unsafeCoerce

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -3,8 +3,12 @@ module Test.Main where
 import Prelude
 import Data.HeytingAlgebra (ff, tt, implies)
 import Data.Ord (abs)
+import Data.Reflectable (reflectType, reifyType)
+import Prim.Boolean (True, False)
+import Prim.Ordering (LT, GT, EQ)
 import Test.Data.Generic.Rep (testGenericRep)
 import Test.Utils (AlmostEff, assert)
+import Type.Proxy (Proxy(..))
 
 main :: AlmostEff
 main = do
@@ -15,6 +19,8 @@ main = do
     testIntDegree
     testRecordInstances
     testGenericRep
+    testReflectType
+    testReifyType
 
 foreign import testNumberShow :: (Number -> String) -> AlmostEff
 
@@ -151,3 +157,33 @@ testRecordInstances = do
   assert "Record top" $
     (top :: { a :: Boolean }).a
     == top
+
+testReflectType :: AlmostEff
+testReflectType = do
+  assert "reflect string" $
+    reflectType (Proxy :: _ "erin!") == "erin!"
+  assert "reflect bool" $
+    reflectType (Proxy :: _ True) == true
+      && reflectType (Proxy :: _ False) == false
+  assert "reflect ord" $
+    reflectType (Proxy :: _ LT) == LT
+      && reflectType (Proxy :: _ GT) == GT
+      && reflectType (Proxy :: _ EQ) == EQ
+  assert "reflect int" $
+    reflectType (Proxy :: _ 42) == 42
+      && reflectType (Proxy :: _ (-42)) == -42
+
+testReifyType :: AlmostEff
+testReifyType = do
+  assert "reify string" $
+    reifyType "erin!" reflectType == "erin!"
+  assert "reify bool" $
+    reifyType true reflectType == true
+      && reifyType false reflectType == false
+  assert "reify ord" $
+    reifyType LT reflectType == LT
+      && reifyType GT reflectType == GT
+      && reifyType EQ reflectType == EQ
+  assert "reify int" $
+    reifyType 42 reflectType == 42
+      && reifyType (-42) reflectType == -42

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -160,30 +160,22 @@ testRecordInstances = do
 
 testReflectType :: AlmostEff
 testReflectType = do
-  assert "reflect string" $
-    reflectType (Proxy :: _ "erin!") == "erin!"
-  assert "reflect bool" $
-    reflectType (Proxy :: _ True) == true
-      && reflectType (Proxy :: _ False) == false
-  assert "reflect ord" $
-    reflectType (Proxy :: _ LT) == LT
-      && reflectType (Proxy :: _ GT) == GT
-      && reflectType (Proxy :: _ EQ) == EQ
-  assert "reflect int" $
-    reflectType (Proxy :: _ 42) == 42
-      && reflectType (Proxy :: _ (-42)) == -42
+  assert "reflectType: Symbol -> String" $ reflectType (Proxy :: _ "erin!") == "erin!"
+  assert "reflectType: Boolean -> Boolean, True" $ reflectType (Proxy :: _ True) == true
+  assert "reflectType: Boolean -> Boolean, False" $ reflectType (Proxy :: _ False) == false
+  assert "reflectType: Ordering -> Ordering, LT" $ reflectType (Proxy :: _ LT) == LT
+  assert "reflectType: Ordering -> Ordering, GT" $ reflectType (Proxy :: _ GT) == GT
+  assert "reflectType: Ordering -> Ordering, EQ" $ reflectType (Proxy :: _ EQ) == EQ
+  assert "reflectType: Int -> Int, 42" $ reflectType (Proxy :: _ 42) == 42
+  assert "reflectType: Int -> Int, -42" $ reflectType (Proxy :: _ (-42)) == -42
 
 testReifyType :: AlmostEff
 testReifyType = do
-  assert "reify string" $
-    reifyType "erin!" reflectType == "erin!"
-  assert "reify bool" $
-    reifyType true reflectType == true
-      && reifyType false reflectType == false
-  assert "reify ord" $
-    reifyType LT reflectType == LT
-      && reifyType GT reflectType == GT
-      && reifyType EQ reflectType == EQ
-  assert "reify int" $
-    reifyType 42 reflectType == 42
-      && reifyType (-42) reflectType == -42
+  assert "reifyType: String -> Symbol" $ reifyType "erin!" reflectType == "erin!"
+  assert "reifyType: Boolean -> Boolean, true" $ reifyType true reflectType == true
+  assert "reifyType: Boolean -> Boolean, false" $ reifyType false reflectType == false
+  assert "reifyType: Ordering -> Ordering, LT" $ reifyType LT reflectType == LT
+  assert "reifyType: Ordering -> Ordering, GT" $ reifyType GT reflectType == GT
+  assert "reifyType: Ordering -> Ordering, EQ" $ reifyType EQ reflectType == EQ
+  assert "reifyType: Int -> Int, 42" $ reifyType 42 reflectType == 42
+  assert "reifyType: Int -> Int, -42" $ reifyType (-42) reflectType == -42


### PR DESCRIPTION
Closes #286. Adds a `Data.Reflectable` module which is where the compiler looks at for the automatically-solved `Reflectable` type class.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
