### PR TITLE
Add visible type applications

### DIFF
--- a/src/Control/Applicative.purs
+++ b/src/Control/Applicative.purs
@@ -30,7 +30,7 @@ import Type.Proxy (Proxy(..))
 -- | - Composition: `pure (<<<) <*> f <*> g <*> h = f <*> (g <*> h)`
 -- | - Homomorphism: `(pure f) <*> (pure x) = pure (f x)`
 -- | - Interchange: `u <*> (pure y) = (pure (_ $ y)) <*> u`
-class Apply f <= Applicative f where
+class Apply f <= Applicative @f where
   pure :: forall a. a -> f a
 
 instance applicativeFn :: Applicative ((->) r) where
@@ -54,15 +54,15 @@ instance applicativeProxy :: Applicative Proxy where
 -- | instance functorF :: Functor F where
 -- |   map = liftA1
 -- | ```
-liftA1 :: forall f a b. Applicative f => (a -> b) -> f a -> f b
+liftA1 :: forall @f @a @b. Applicative f => (a -> b) -> f a -> f b
 liftA1 f a = pure f <*> a
 
 -- | Perform an applicative action when a condition is true.
-when :: forall m. Applicative m => Boolean -> m Unit -> m Unit
+when :: forall @m. Applicative m => Boolean -> m Unit -> m Unit
 when true m = m
 when false _ = pure unit
 
 -- | Perform an applicative action unless a condition is true.
-unless :: forall m. Applicative m => Boolean -> m Unit -> m Unit
+unless :: forall @m. Applicative m => Boolean -> m Unit -> m Unit
 unless false m = m
 unless true _ = pure unit

--- a/src/Control/Apply.purs
+++ b/src/Control/Apply.purs
@@ -42,7 +42,7 @@ import Type.Proxy (Proxy(..))
 -- | - Associative composition: `(<<<) <$> f <*> g <*> h = f <*> (g <*> h)`
 -- |
 -- | Formally, `Apply` represents a strong lax semi-monoidal endofunctor.
-class Functor f <= Apply f where
+class Functor f <= Apply @f where
   apply :: forall a b. f (a -> b) -> f a -> f b
 
 infixl 4 apply as <*>
@@ -59,13 +59,13 @@ instance applyProxy :: Apply Proxy where
   apply _ _ = Proxy
 
 -- | Combine two effectful actions, keeping only the result of the first.
-applyFirst :: forall a b f. Apply f => f a -> f b -> f a
+applyFirst :: forall @f @a @b. Apply f => f a -> f b -> f a
 applyFirst a b = const <$> a <*> b
 
 infixl 4 applyFirst as <*
 
 -- | Combine two effectful actions, keeping only the result of the second.
-applySecond :: forall a b f. Apply f => f a -> f b -> f b
+applySecond :: forall @f @a @b. Apply f => f a -> f b -> f b
 applySecond a b = const identity <$> a <*> b
 
 infixl 4 applySecond as *>
@@ -78,20 +78,20 @@ infixl 4 applySecond as *>
 -- | lift2 add Nothing (Just 2) == Nothing
 -- |```
 -- |
-lift2 :: forall a b c f. Apply f => (a -> b -> c) -> f a -> f b -> f c
+lift2 :: forall @f @a @b @c. Apply f => (a -> b -> c) -> f a -> f b -> f c
 lift2 f a b = f <$> a <*> b
 
 -- | Lift a function of three arguments to a function which accepts and returns
 -- | values wrapped with the type constructor `f`.
-lift3 :: forall a b c d f. Apply f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d
+lift3 :: forall @f @a @b @c @d. Apply f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d
 lift3 f a b c = f <$> a <*> b <*> c
 
 -- | Lift a function of four arguments to a function which accepts and returns
 -- | values wrapped with the type constructor `f`.
-lift4 :: forall a b c d e f. Apply f => (a -> b -> c -> d -> e) -> f a -> f b -> f c -> f d -> f e
+lift4 :: forall @f @a @b @c @d @e. Apply f => (a -> b -> c -> d -> e) -> f a -> f b -> f c -> f d -> f e
 lift4 f a b c d = f <$> a <*> b <*> c <*> d
 
 -- | Lift a function of five arguments to a function which accepts and returns
 -- | values wrapped with the type constructor `f`.
-lift5 :: forall a b c d e f g. Apply f => (a -> b -> c -> d -> e -> g) -> f a -> f b -> f c -> f d -> f e -> f g
+lift5 :: forall @f @a @b @c @d @e @g. Apply f => (a -> b -> c -> d -> e -> g) -> f a -> f b -> f c -> f d -> f e -> f g
 lift5 f a b c d e = f <$> a <*> b <*> c <*> d <*> e

--- a/src/Control/Bind.purs
+++ b/src/Control/Bind.purs
@@ -53,7 +53,7 @@ import Type.Proxy (Proxy(..))
 -- |    y <- m2 x
 -- |    m3 x y
 -- | ```
-class Apply m <= Bind m where
+class Apply m <= Bind @m where
   bind :: forall a b. m a -> (a -> m b) -> m b
 
 infixl 1 bind as >>=
@@ -63,7 +63,7 @@ infixl 1 bind as >>=
 -- | ```purescript
 -- | print =<< random
 -- | ```
-bindFlipped :: forall m a b. Bind m => (a -> m b) -> m a -> m b
+bindFlipped :: forall @m @a @b. Bind m => (a -> m b) -> m a -> m b
 bindFlipped = flip bind
 
 infixr 1 bindFlipped as =<<
@@ -104,8 +104,8 @@ instance bindProxy :: Bind Proxy where
 -- |
 -- | An example is the `Unit` type, since there is only one
 -- | possible value which can be returned.
-class Discard a where
-  discard :: forall f b. Bind f => f a -> (a -> f b) -> f b
+class Discard @a where
+  discard :: forall @f @b. Bind f => f a -> (a -> f b) -> f b
 
 instance discardUnit :: Discard Unit where
   discard = bind
@@ -114,7 +114,7 @@ instance discardProxy :: Discard (Proxy a) where
   discard = bind
 
 -- | Collapse two applications of a monadic type constructor into one.
-join :: forall a m. Bind m => m (m a) -> m a
+join :: forall @m a. Bind m => m (m a) -> m a
 join m = m >>= identity
 
 -- | Forwards Kleisli composition.
@@ -126,13 +126,13 @@ join m = m >>= identity
 -- |
 -- | third = tail >=> tail >=> head
 -- | ```
-composeKleisli :: forall a b c m. Bind m => (a -> m b) -> (b -> m c) -> a -> m c
+composeKleisli :: forall @m @a @b @c. Bind m => (a -> m b) -> (b -> m c) -> a -> m c
 composeKleisli f g a = f a >>= g
 
 infixr 1 composeKleisli as >=>
 
 -- | Backwards Kleisli composition.
-composeKleisliFlipped :: forall a b c m. Bind m => (b -> m c) -> (a -> m b) -> a -> m c
+composeKleisliFlipped :: forall @m @a @b @c. Bind m => (b -> m c) -> (a -> m b) -> a -> m c
 composeKleisliFlipped f g a = f =<< g a
 
 infixr 1 composeKleisliFlipped as <=<
@@ -146,5 +146,5 @@ infixr 1 composeKleisliFlipped as <=<
 -- |          (trace "Heads")
 -- |          (trace "Tails")
 -- | ```
-ifM :: forall a m. Bind m => m Boolean -> m a -> m a -> m a
+ifM :: forall @m @a. Bind m => m Boolean -> m a -> m a -> m a
 ifM cond t f = cond >>= \cond' -> if cond' then t else f

--- a/src/Control/Category.purs
+++ b/src/Control/Category.purs
@@ -14,7 +14,7 @@ import Control.Semigroupoid (class Semigroupoid, compose, (<<<), (>>>))
 -- |
 -- | - Identity: `identity <<< p = p <<< identity = p`
 class Category :: forall k. (k -> k -> Type) -> Constraint
-class Semigroupoid a <= Category a where
+class Semigroupoid a <= Category @a where
   identity :: forall t. a t t
 
 instance categoryFn :: Category (->) where

--- a/src/Control/Monad.purs
+++ b/src/Control/Monad.purs
@@ -28,7 +28,7 @@ import Type.Proxy (Proxy)
 -- |
 -- | - Left Identity: `pure x >>= f = f x`
 -- | - Right Identity: `x >>= pure = x`
-class (Applicative m, Bind m) <= Monad m
+class (Applicative m, Bind m) <= Monad @m
 
 instance monadFn :: Monad ((->) r)
 
@@ -47,21 +47,21 @@ instance monadProxy :: Monad Proxy
 -- | instance functorF :: Functor F where
 -- |   map = liftM1
 -- | ```
-liftM1 :: forall m a b. Monad m => (a -> b) -> m a -> m b
+liftM1 :: forall @m @a @b. Monad m => (a -> b) -> m a -> m b
 liftM1 f a = do
   a' <- a
   pure (f a')
 
 -- | Perform a monadic action when a condition is true, where the conditional
 -- | value is also in a monadic context.
-whenM :: forall m. Monad m => m Boolean -> m Unit -> m Unit
+whenM :: forall @m. Monad m => m Boolean -> m Unit -> m Unit
 whenM mb m = do
   b <- mb
   when b m
 
 -- | Perform a monadic action unless a condition is true, where the conditional
 -- | value is also in a monadic context.
-unlessM :: forall m. Monad m => m Boolean -> m Unit -> m Unit
+unlessM :: forall @m. Monad m => m Boolean -> m Unit -> m Unit
 unlessM mb m =  do
   b <- mb
   unless b m
@@ -79,7 +79,7 @@ unlessM mb m =  do
 -- produce loops when used with other default implementations
 -- (i.e. `liftA1`).
 -- See https://github.com/purescript/purescript-prelude/issues/232
-ap :: forall m a b. Monad m => m (a -> b) -> m a -> m b
+ap :: forall @m @a @b. Monad m => m (a -> b) -> m a -> m b
 ap f a = do
   f' <- f
   a' <- a

--- a/src/Control/Semigroupoid.purs
+++ b/src/Control/Semigroupoid.purs
@@ -10,8 +10,8 @@ module Control.Semigroupoid where
 -- | One example of a `Semigroupoid` is the function type constructor `(->)`,
 -- | with `(<<<)` defined as function composition.
 class Semigroupoid :: forall k. (k -> k -> Type) -> Constraint
-class Semigroupoid a where
-  compose :: forall b c d. a c d -> a b c -> a b d
+class Semigroupoid @a where
+  compose :: forall @b @c @d. a c d -> a b c -> a b d
 
 instance semigroupoidFn :: Semigroupoid (->) where
   compose f g x = f (g x)
@@ -19,7 +19,7 @@ instance semigroupoidFn :: Semigroupoid (->) where
 infixr 9 compose as <<<
 
 -- | Forwards composition, or `compose` with its arguments reversed.
-composeFlipped :: forall a b c d. Semigroupoid a => a b c -> a c d -> a b d
+composeFlipped :: forall @a @b @c @d. Semigroupoid a => a b c -> a c d -> a b d
 composeFlipped f g = compose g f
 
 infixr 9 composeFlipped as >>>

--- a/src/Data/BooleanAlgebra.purs
+++ b/src/Data/BooleanAlgebra.purs
@@ -19,7 +19,7 @@ import Type.Proxy (Proxy)
 -- |
 -- | - Excluded middle:
 -- |   - `a || not a = tt`
-class HeytingAlgebra a <= BooleanAlgebra a
+class HeytingAlgebra a <= BooleanAlgebra @a
 
 instance booleanAlgebraBoolean :: BooleanAlgebra Boolean
 instance booleanAlgebraUnit :: BooleanAlgebra Unit
@@ -30,7 +30,7 @@ instance booleanAlgebraProxy :: BooleanAlgebra (Proxy a)
 -- | A class for records where all fields have `BooleanAlgebra` instances, used
 -- | to implement the `BooleanAlgebra` instance for records.
 class BooleanAlgebraRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
-class HeytingAlgebraRecord rowlist row subrow <= BooleanAlgebraRecord rowlist row subrow | rowlist -> subrow
+class HeytingAlgebraRecord rowlist row subrow <= BooleanAlgebraRecord @rowlist @row @subrow | rowlist -> subrow
 
 instance booleanAlgebraRecordNil :: BooleanAlgebraRecord RL.Nil row ()
 

--- a/src/Data/Bounded.purs
+++ b/src/Data/Bounded.purs
@@ -22,7 +22,7 @@ import Type.Proxy (Proxy(..))
 -- | Instances should satisfy the following law in addition to the `Ord` laws:
 -- |
 -- | - Bounded: `bottom <= a <= top`
-class Ord a <= Bounded a where
+class Ord a <= Bounded @a where
   top :: a
   bottom :: a
 
@@ -68,7 +68,7 @@ instance boundedProxy :: Bounded (Proxy a) where
   top = Proxy
 
 class BoundedRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
-class OrdRecord rowlist row <= BoundedRecord rowlist row subrow | rowlist -> subrow where
+class OrdRecord rowlist row <= BoundedRecord @rowlist @row @subrow | rowlist -> subrow where
   topRecord :: Proxy rowlist -> Proxy row -> Record subrow
   bottomRecord :: Proxy rowlist -> Proxy row -> Record subrow
 

--- a/src/Data/Bounded.purs
+++ b/src/Data/Bounded.purs
@@ -69,12 +69,12 @@ instance boundedProxy :: Bounded (Proxy a) where
 
 class BoundedRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class OrdRecord rowlist row <= BoundedRecord @rowlist @row @subrow | rowlist -> subrow where
-  topRecord :: Proxy rowlist -> Proxy row -> Record subrow
-  bottomRecord :: Proxy rowlist -> Proxy row -> Record subrow
+  topRecord :: Record subrow
+  bottomRecord :: Record subrow
 
 instance boundedRecordNil :: BoundedRecord RL.Nil row () where
-  topRecord _ _ = {}
-  bottomRecord _ _ = {}
+  topRecord = {}
+  bottomRecord = {}
 
 instance boundedRecordCons ::
   ( IsSymbol key
@@ -84,22 +84,22 @@ instance boundedRecordCons ::
   , BoundedRecord rowlistTail row subrowTail
   ) =>
   BoundedRecord (RL.Cons key focus rowlistTail) row subrow where
-  topRecord _ rowProxy = insert top tail
+  topRecord = insert top tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-    tail = topRecord (Proxy :: Proxy rowlistTail) rowProxy
+    tail = topRecord @rowlistTail @row
 
   bottomRecord _ rowProxy = insert bottom tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-    tail = bottomRecord (Proxy :: Proxy rowlistTail) rowProxy
+    tail = bottomRecord @rowlistTail @row
 
 instance boundedRecord ::
   ( RL.RowToList row list
   , BoundedRecord list row row
   ) =>
   Bounded (Record row) where
-  top = topRecord (Proxy :: Proxy list) (Proxy :: Proxy row)
-  bottom = bottomRecord (Proxy :: Proxy list) (Proxy :: Proxy row)
+  top = topRecord @list @row
+  bottom = bottomRecord @list @row

--- a/src/Data/CommutativeRing.purs
+++ b/src/Data/CommutativeRing.purs
@@ -20,7 +20,7 @@ import Type.Proxy (Proxy)
 -- | laws:
 -- |
 -- | - Commutative multiplication: `a * b = b * a`
-class Ring a <= CommutativeRing a
+class Ring a <= CommutativeRing @a
 
 instance commutativeRingInt :: CommutativeRing Int
 instance commutativeRingNumber :: CommutativeRing Number
@@ -31,7 +31,7 @@ instance commutativeRingProxy :: CommutativeRing (Proxy a)
 
 -- | A class for records where all fields have `CommutativeRing` instances, used
 -- | to implement the `CommutativeRing` instance for records.
-class RingRecord rowlist row subrow <= CommutativeRingRecord rowlist row subrow | rowlist -> subrow
+class RingRecord rowlist row subrow <= CommutativeRingRecord @rowlist @row @subrow | rowlist -> subrow
 
 instance commutativeRingRecordNil :: CommutativeRingRecord RL.Nil row ()
 

--- a/src/Data/DivisionRing.purs
+++ b/src/Data/DivisionRing.purs
@@ -26,7 +26,7 @@ import Data.Semiring (class Semiring, add, mul, one, zero, (*), (+))
 -- |
 -- | If a type has both `DivisionRing` and `CommutativeRing` instances, then
 -- | it is a field and should have a `Field` instance.
-class Ring a <= DivisionRing a where
+class Ring a <= DivisionRing @a where
   recip :: a -> a
 
 -- | Left division, defined as `leftDiv a b = recip b * a`. Left and right
@@ -37,7 +37,7 @@ class Ring a <= DivisionRing a where
 -- | equivalent to `div` from the `EuclideanRing` class. When working
 -- | abstractly, `div` should generally be preferred, unless you know that you
 -- | need your code to work with noncommutative rings.
-leftDiv :: forall a. DivisionRing a => a -> a -> a
+leftDiv :: forall @a. DivisionRing a => a -> a -> a
 leftDiv a b = recip b * a
 
 -- | Right division, defined as `rightDiv a b = a * recip b`. Left and right
@@ -48,7 +48,7 @@ leftDiv a b = recip b * a
 -- | equivalent to `div` from the `EuclideanRing` class. When working
 -- | abstractly, `div` should generally be preferred, unless you know that you
 -- | need your code to work with noncommutative rings.
-rightDiv :: forall a. DivisionRing a => a -> a -> a
+rightDiv :: forall @a. DivisionRing a => a -> a -> a
 rightDiv a b = a * recip b
 
 instance divisionringNumber :: DivisionRing Number where

--- a/src/Data/Eq.purs
+++ b/src/Data/Eq.purs
@@ -32,14 +32,14 @@ import Type.Proxy (Proxy(..))
 -- | class due to the presence of `NaN`, since `NaN /= NaN`. Additionally,
 -- | computing with `Number` can result in a loss of precision, so sometimes
 -- | values that should be equivalent are not.
-class Eq a where
+class Eq @a where
   eq :: a -> a -> Boolean
 
 infix 4 eq as ==
 
 -- | `notEq` tests whether one value is _not equal_ to another. Shorthand for
 -- | `not (eq x y)`.
-notEq :: forall a. Eq a => a -> a -> Boolean
+notEq :: forall @a. Eq a => a -> a -> Boolean
 notEq x y = (x == y) == false
 
 infix 4 notEq as /=
@@ -83,19 +83,19 @@ foreign import eqStringImpl :: String -> String -> Boolean
 foreign import eqArrayImpl :: forall a. (a -> a -> Boolean) -> Array a -> Array a -> Boolean
 
 -- | The `Eq1` type class represents type constructors with decidable equality.
-class Eq1 f where
-  eq1 :: forall a. Eq a => f a -> f a -> Boolean
+class Eq1 @f where
+  eq1 :: forall @a. Eq a => f a -> f a -> Boolean
 
 instance eq1Array :: Eq1 Array where
   eq1 = eq
 
-notEq1 :: forall f a. Eq1 f => Eq a => f a -> f a -> Boolean
+notEq1 :: forall @f @a. Eq1 f => Eq a => f a -> f a -> Boolean
 notEq1 x y = (x `eq1` y) == false
 
 -- | A class for records where all fields have `Eq` instances, used to implement
 -- | the `Eq` instance for records.
 class EqRecord :: RL.RowList Type -> Row Type -> Constraint
-class EqRecord rowlist row where
+class EqRecord @rowlist @row where
   eqRecord :: Proxy rowlist -> Record row -> Record row -> Boolean
 
 instance eqRowNil :: EqRecord RL.Nil row where

--- a/src/Data/Eq.purs
+++ b/src/Data/Eq.purs
@@ -96,10 +96,10 @@ notEq1 x y = (x `eq1` y) == false
 -- | the `Eq` instance for records.
 class EqRecord :: RL.RowList Type -> Row Type -> Constraint
 class EqRecord @rowlist @row where
-  eqRecord :: Proxy rowlist -> Record row -> Record row -> Boolean
+  eqRecord :: Record row -> Record row -> Boolean
 
 instance eqRowNil :: EqRecord RL.Nil row where
-  eqRecord _ _ _ = true
+  eqRecord _ _ = true
 
 instance eqRowCons ::
   ( EqRecord rowlistTail row
@@ -108,8 +108,8 @@ instance eqRowCons ::
   , Eq focus
   ) =>
   EqRecord (RL.Cons key focus rowlistTail) row where
-  eqRecord _ ra rb = (get ra == get rb) && tail
+  eqRecord ra rb = (get ra == get rb) && tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     get = unsafeGet key :: Record row -> focus
-    tail = eqRecord (Proxy :: Proxy rowlistTail) ra rb
+    tail = eqRecord @rowlisTail ra rb

--- a/src/Data/EuclideanRing.purs
+++ b/src/Data/EuclideanRing.purs
@@ -60,7 +60,7 @@ import Data.Semiring (class Semiring, add, mul, one, zero, (*), (+))
 -- | instance used truncating division. As of 4.x, the `EuclideanRing Int`
 -- | instance uses Euclidean division. Additional functions `quot` and `rem` are
 -- | supplied if truncating division is desired.
-class CommutativeRing a <= EuclideanRing a where
+class CommutativeRing a <= EuclideanRing @a where
   degree :: a -> Int
   div :: a -> a -> a
   mod :: a -> a -> a
@@ -84,14 +84,14 @@ foreign import intMod :: Int -> Int -> Int
 foreign import numDiv :: Number -> Number -> Number
 
 -- | The *greatest common divisor* of two values.
-gcd :: forall a. Eq a => EuclideanRing a => a -> a -> a
+gcd :: forall @a. Eq a => EuclideanRing a => a -> a -> a
 gcd a b =
   if b == zero
     then a
     else gcd b (a `mod` b)
 
 -- | The *least common multiple* of two values.
-lcm :: forall a. Eq a => EuclideanRing a => a -> a -> a
+lcm :: forall @a. Eq a => EuclideanRing a => a -> a -> a
 lcm a b =
   if a == zero || b == zero
     then zero

--- a/src/Data/Field.purs
+++ b/src/Data/Field.purs
@@ -36,6 +36,6 @@ import Data.Semiring (class Semiring, add, mul, one, zero, (*), (+))
 -- | defined in libraries. Instead, simply define `EuclideanRing` and
 -- | `DivisionRing` instances, and this will permit your type to be used with a
 -- | `Field` constraint.
-class (EuclideanRing a, DivisionRing a) <= Field a
+class (EuclideanRing a, DivisionRing a) <= Field @a
 
 instance field :: (EuclideanRing a, DivisionRing a) => Field a

--- a/src/Data/Function.purs
+++ b/src/Data/Function.purs
@@ -23,7 +23,7 @@ import Data.Ring ((-))
 -- |
 -- | flip const 1 "two" == const "two" 1 == "two"
 -- | ```
-flip :: forall a b c. (a -> b -> c) -> b -> a -> c
+flip :: forall @a @b @c. (a -> b -> c) -> b -> a -> c
 flip f b a = f a b
 
 -- | Returns its first argument and ignores its second.
@@ -37,13 +37,13 @@ flip f b a = f a b
 -- | ```purescript
 -- | const 1 = \_ -> 1
 -- | ```
-const :: forall a b. a -> b -> a
+const :: forall @a @b. a -> b -> a
 const a _ = a
 
 -- | Applies a function to an argument. This is primarily used as the operator
 -- | `($)` which allows parentheses to be omitted in some cases, or as a
 -- | natural way to apply a chain of composed functions to a value.
-apply :: forall a b. (a -> b) -> a -> b
+apply :: forall @a @b. (a -> b) -> a -> b
 apply f x = f x
 
 -- | Applies a function to an argument: the reverse of `(#)`.
@@ -69,7 +69,7 @@ infixr 0 apply as $
 -- | Applies an argument to a function. This is primarily used as the `(#)`
 -- | operator, which allows parentheses to be omitted in some cases, or as a
 -- | natural way to apply a value to a chain of composed functions.
-applyFlipped :: forall a b. a -> (a -> b) -> b
+applyFlipped :: forall @a @b. a -> (a -> b) -> b
 applyFlipped x f = f x
 
 -- | Applies an argument to a function: the reverse of `($)`.
@@ -99,7 +99,7 @@ infixl 1 applyFlipped as #
 -- | ```purescript
 -- | applyN (_ + 1) 10 0 == 10
 -- | ```
-applyN :: forall a. (a -> a) -> Int -> a -> a
+applyN :: forall @a. (a -> a) -> Int -> a -> a
 applyN f = go
   where
   go n acc
@@ -114,5 +114,5 @@ applyN f = go
 -- | compareX :: forall r. { x :: Number | r } -> { x :: Number | r } -> Ordering
 -- | compareX = compare `on` _.x
 -- | ```
-on :: forall a b c. (b -> b -> c) -> (a -> b) -> a -> a -> c
+on :: forall @a @b @c. (b -> b -> c) -> (a -> b) -> a -> a -> c
 on f g x y = g x `f` g y

--- a/src/Data/Functor.purs
+++ b/src/Data/Functor.purs
@@ -22,7 +22,7 @@ import Type.Proxy (Proxy(..))
 -- |
 -- | - Identity: `map identity = identity`
 -- | - Composition: `map (f <<< g) = map f <<< map g`
-class Functor f where
+class Functor @f where
   map :: forall a b. (a -> b) -> f a -> f b
 
 infixl 4 map as <$>
@@ -32,7 +32,7 @@ infixl 4 map as <$>
 -- | ```purescript
 -- | [1, 2, 3] <#> \n -> n * n
 -- | ```
-mapFlipped :: forall f a b. Functor f => f a -> (a -> b) -> f b
+mapFlipped :: forall @f a b. Functor f => f a -> (a -> b) -> f b
 mapFlipped fa f = f <$> fa
 
 infixl 1 mapFlipped as <#>
@@ -60,18 +60,18 @@ foreign import arrayMap :: forall a b. (a -> b) -> Array a -> Array b
 -- |   print n
 -- |   print (n * n)
 -- | ```
-void :: forall f a. Functor f => f a -> f Unit
+void :: forall @f a. Functor f => f a -> f Unit
 void = map (const unit)
 
 -- | Ignore the return value of a computation, using the specified return value
 -- | instead.
-voidRight :: forall f a b. Functor f => a -> f b -> f a
+voidRight :: forall @f a b. Functor f => a -> f b -> f a
 voidRight x = map (const x)
 
 infixl 4 voidRight as <$
 
 -- | A version of `voidRight` with its arguments flipped.
-voidLeft :: forall f a b. Functor f => f a -> b -> f b
+voidLeft :: forall @f a b. Functor f => f a -> b -> f b
 voidLeft f x = const x <$> f
 
 infixl 4 voidLeft as $>
@@ -94,7 +94,7 @@ infixl 4 voidLeft as $>
 -- | flap (-) 3 4 == 1
 -- | threeve <$> Just 1 <@> 'a' <*> Just true == Just (threeve 1 'a' true)
 -- | ```
-flap :: forall f a b. Functor f => f (a -> b) -> a -> f b
+flap :: forall @f a b. Functor f => f (a -> b) -> a -> f b
 flap ff x = map (\f -> f x) ff
 
 infixl 4 flap as <@>

--- a/src/Data/Generic/Rep.purs
+++ b/src/Data/Generic/Rep.purs
@@ -58,5 +58,5 @@ class Generic @a @rep | a -> rep where
   to :: rep -> a
   from :: a -> rep
 
-repOf :: forall a@ @rep. Generic a rep => Proxy a -> Proxy rep
+repOf :: forall @a @rep. Generic a rep => Proxy a -> Proxy rep
 repOf _ = Proxy

--- a/src/Data/Generic/Rep.purs
+++ b/src/Data/Generic/Rep.purs
@@ -54,9 +54,9 @@ instance showArgument :: Show a => Show (Argument a) where
 
 -- | The `Generic` class asserts the existence of a type function from types
 -- | to their representations using the type constructors defined in this module.
-class Generic a rep | a -> rep where
+class Generic @a @rep | a -> rep where
   to :: rep -> a
   from :: a -> rep
 
-repOf :: forall a rep. Generic a rep => Proxy a -> Proxy rep
+repOf :: forall a@ @rep. Generic a rep => Proxy a -> Proxy rep
 repOf _ = Proxy

--- a/src/Data/HeytingAlgebra.purs
+++ b/src/Data/HeytingAlgebra.purs
@@ -108,12 +108,12 @@ foreign import boolNot :: Boolean -> Boolean
 -- | to implement the `HeytingAlgebra` instance for records.
 class HeytingAlgebraRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class HeytingAlgebraRecord @rowlist @row @subrow | rowlist -> subrow where
-  ffRecord :: Proxy rowlist -> Proxy row -> Record subrow
-  ttRecord :: Proxy rowlist -> Proxy row -> Record subrow
-  impliesRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
-  disjRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
-  conjRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
-  notRecord :: Proxy rowlist -> Record row -> Record subrow
+  ffRecord :: Record subrow
+  ttRecord :: Record subrow
+  impliesRecord :: Record row -> Record row -> Record subrow
+  disjRecord :: Record row -> Record row -> Record subrow
+  conjRecord :: Record row -> Record row -> Record subrow
+  notRecord :: Record row -> Record subrow
 
 instance heytingAlgebraRecordNil :: HeytingAlgebraRecord RL.Nil row () where
   conjRecord _ _ _ = {}
@@ -130,42 +130,42 @@ instance heytingAlgebraRecordCons ::
   , HeytingAlgebra focus
   ) =>
   HeytingAlgebraRecord (RL.Cons key focus rowlistTail) row subrow where
-  conjRecord _ ra rb = insert (conj (get ra) (get rb)) tail
+  conjRecord ra rb = insert (conj (get ra) (get rb)) tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     get = unsafeGet key :: Record row -> focus
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-    tail = conjRecord (Proxy :: Proxy rowlistTail) ra rb
+    tail = conjRecord @rowlistTail ra rb
 
-  disjRecord _ ra rb = insert (disj (get ra) (get rb)) tail
+  disjRecord ra rb = insert (disj (get ra) (get rb)) tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     get = unsafeGet key :: Record row -> focus
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-    tail = disjRecord (Proxy :: Proxy rowlistTail) ra rb
+    tail = disjRecord @rowlistTail ra rb
 
-  impliesRecord _ ra rb = insert (implies (get ra) (get rb)) tail
+  impliesRecord ra rb = insert (implies (get ra) (get rb)) tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     get = unsafeGet key :: Record row -> focus
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-    tail = impliesRecord (Proxy :: Proxy rowlistTail) ra rb
+    tail = impliesRecord @rowlistTail ra rb
 
-  ffRecord _ row = insert ff tail
+  ffRecord = insert ff tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-    tail = ffRecord (Proxy :: Proxy rowlistTail) row
+    tail = ffRecord @rowlistTail @row
 
-  notRecord _ row = insert (not (get row)) tail
+  notRecord row = insert (not (get row)) tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     get = unsafeGet key :: Record row -> focus
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-    tail = notRecord (Proxy :: Proxy rowlistTail) row
+    tail = notRecord @rowlistTail row
 
-  ttRecord _ row = insert tt tail
+  ttRecord = insert tt tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-    tail = ttRecord (Proxy :: Proxy rowlistTail) row
+    tail = ttRecord @rowlistTail @row

--- a/src/Data/HeytingAlgebra.purs
+++ b/src/Data/HeytingAlgebra.purs
@@ -49,7 +49,7 @@ import Type.Proxy (Proxy(..))
 -- |   - ``a `implies` (b && c) = (a `implies` b) && (a `implies` c)``
 -- | - Complemented:
 -- |   - ``not a = a `implies` ff``
-class HeytingAlgebra a where
+class HeytingAlgebra @a where
   ff :: a
   tt :: a
   implies :: a -> a -> a
@@ -107,7 +107,7 @@ foreign import boolNot :: Boolean -> Boolean
 -- | A class for records where all fields have `HeytingAlgebra` instances, used
 -- | to implement the `HeytingAlgebra` instance for records.
 class HeytingAlgebraRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
-class HeytingAlgebraRecord rowlist row subrow | rowlist -> subrow where
+class HeytingAlgebraRecord @rowlist @row @subrow | rowlist -> subrow where
   ffRecord :: Proxy rowlist -> Proxy row -> Record subrow
   ttRecord :: Proxy rowlist -> Proxy row -> Record subrow
   impliesRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow

--- a/src/Data/Monoid.purs
+++ b/src/Data/Monoid.purs
@@ -101,10 +101,10 @@ guard false _ = mempty
 -- | implement the `Monoid` instance for records.
 class MonoidRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class SemigroupRecord rowlist row subrow <= MonoidRecord @rowlist @row @subrow | rowlist -> row subrow where
-  memptyRecord :: Proxy rowlist -> Record subrow
+  memptyRecord :: Record subrow
 
 instance monoidRecordNil :: MonoidRecord RL.Nil row () where
-  memptyRecord _ = {}
+  memptyRecord = {}
 
 instance monoidRecordCons ::
   ( IsSymbol key
@@ -113,8 +113,8 @@ instance monoidRecordCons ::
   , MonoidRecord rowlistTail row subrowTail
   ) =>
   MonoidRecord (RL.Cons key focus rowlistTail) row subrow where
-  memptyRecord _ = insert mempty tail
+  memptyRecord = insert mempty tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-    tail = memptyRecord (Proxy :: Proxy rowlistTail)
+    tail = memptyRecord @rowlistTail

--- a/src/Data/Monoid.purs
+++ b/src/Data/Monoid.purs
@@ -43,7 +43,7 @@ import Type.Proxy (Proxy(..))
 -- |
 -- | In the above ambiguous situation, we could use `Additive`
 -- | for the first situation or `Multiplicative` for the second one.
-class Semigroup m <= Monoid m where
+class Semigroup m <= Monoid @m where
   mempty :: m
 
 instance monoidUnit :: Monoid Unit where
@@ -82,7 +82,7 @@ instance monoidRecord :: (RL.RowToList row list, MonoidRecord list row row) => M
 -- | power [1,2] (-3) == []
 -- | ```
 -- |
-power :: forall m. Monoid m => m -> Int -> m
+power :: forall @m. Monoid m => m -> Int -> m
 power x = go
   where
   go :: Int -> m
@@ -93,14 +93,14 @@ power x = go
     | otherwise = let x' = go (p / 2) in x' <> x' <> x
 
 -- | Allow or "truncate" a Monoid to its `mempty` value based on a condition.
-guard :: forall m. Monoid m => Boolean -> m -> m
+guard :: forall @m. Monoid m => Boolean -> m -> m
 guard true a = a
 guard false _ = mempty
 
 -- | A class for records where all fields have `Monoid` instances, used to
 -- | implement the `Monoid` instance for records.
 class MonoidRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
-class SemigroupRecord rowlist row subrow <= MonoidRecord rowlist row subrow | rowlist -> row subrow where
+class SemigroupRecord rowlist row subrow <= MonoidRecord @rowlist @row @subrow | rowlist -> row subrow where
   memptyRecord :: Proxy rowlist -> Record subrow
 
 instance monoidRecordNil :: MonoidRecord RL.Nil row () where

--- a/src/Data/Monoid/Additive.purs
+++ b/src/Data/Monoid/Additive.purs
@@ -11,7 +11,7 @@ import Data.Ord (class Ord1)
 -- | Additive x <> Additive y == Additive (x + y)
 -- | (mempty :: Additive _) == Additive zero
 -- | ```
-newtype Additive a = Additive a
+newtype Additive @a = Additive a
 
 derive newtype instance eqAdditive :: Eq a => Eq (Additive a)
 derive instance eq1Additive :: Eq1 Additive

--- a/src/Data/Monoid/Conj.purs
+++ b/src/Data/Monoid/Conj.purs
@@ -12,7 +12,7 @@ import Data.Ord (class Ord1)
 -- | Conj x <> Conj y == Conj (x && y)
 -- | (mempty :: Conj _) == Conj tt
 -- | ```
-newtype Conj a = Conj a
+newtype Conj @a = Conj a
 
 derive newtype instance eqConj :: Eq a => Eq (Conj a)
 derive instance eq1Conj :: Eq1 Conj

--- a/src/Data/Monoid/Disj.purs
+++ b/src/Data/Monoid/Disj.purs
@@ -12,7 +12,7 @@ import Data.Ord (class Ord1)
 -- | Disj x <> Disj y == Disj (x || y)
 -- | (mempty :: Disj _) == Disj bottom
 -- | ```
-newtype Disj a = Disj a
+newtype Disj @a = Disj a
 
 derive newtype instance eqDisj :: Eq a => Eq (Disj a)
 derive instance eq1Disj :: Eq1 Disj

--- a/src/Data/Monoid/Dual.purs
+++ b/src/Data/Monoid/Dual.purs
@@ -11,7 +11,7 @@ import Data.Ord (class Ord1)
 -- | Dual x <> Dual y == Dual (y <> x)
 -- | (mempty :: Dual _) == Dual mempty
 -- | ```
-newtype Dual a = Dual a
+newtype Dual @a = Dual a
 
 derive newtype instance eqDual :: Eq a => Eq (Dual a)
 derive instance eq1Dual :: Eq1 Dual

--- a/src/Data/Monoid/Endo.purs
+++ b/src/Data/Monoid/Endo.purs
@@ -12,7 +12,7 @@ import Prelude
 -- | (mempty :: Endo _) == Endo identity
 -- | ```
 newtype Endo :: forall k. (k -> k -> Type) -> k -> Type
-newtype Endo c a = Endo (c a a)
+newtype Endo @c @a = Endo (c a a)
 
 derive newtype instance eqEndo :: Eq (c a a) => Eq (Endo c a)
 

--- a/src/Data/Monoid/Multiplicative.purs
+++ b/src/Data/Monoid/Multiplicative.purs
@@ -11,7 +11,7 @@ import Data.Ord (class Ord1)
 -- | Multiplicative x <> Multiplicative y == Multiplicative (x * y)
 -- | (mempty :: Multiplicative _) == Multiplicative one
 -- | ```
-newtype Multiplicative a = Multiplicative a
+newtype Multiplicative @a = Multiplicative a
 
 derive newtype instance eqMultiplicative :: Eq a => Eq (Multiplicative a)
 derive instance eq1Multiplicative :: Eq1 Multiplicative

--- a/src/Data/NaturalTransformation.purs
+++ b/src/Data/NaturalTransformation.purs
@@ -15,6 +15,6 @@ module Data.NaturalTransformation where
 -- | enforced here; that the types are of kind `k -> Type` is enough for our
 -- | purposes.
 type NaturalTransformation :: forall k. (k -> Type) -> (k -> Type) -> Type
-type NaturalTransformation f g = forall a. f a -> g a
+type NaturalTransformation @f @g = forall a. f a -> g a
 
 infixr 4 type NaturalTransformation as ~>

--- a/src/Data/Ord.purs
+++ b/src/Data/Ord.purs
@@ -236,10 +236,10 @@ instance ord1Array :: Ord1 Array where
 
 class OrdRecord :: RL.RowList Type -> Row Type -> Constraint
 class EqRecord rowlist row <= OrdRecord @rowlist @row where
-  compareRecord :: Proxy rowlist -> Record row -> Record row -> Ordering
+  compareRecord :: Record row -> Record row -> Ordering
 
 instance ordRecordNil :: OrdRecord RL.Nil row where
-  compareRecord _ _ _ = EQ
+  compareRecord _ _ = EQ
 
 instance ordRecordCons ::
   ( OrdRecord rowlistTail row
@@ -248,11 +248,11 @@ instance ordRecordCons ::
   , Ord focus
   ) =>
   OrdRecord (RL.Cons key focus rowlistTail) row where
-  compareRecord _ ra rb =
+  compareRecord ra rb =
     if left /= EQ then left
-    else compareRecord (Proxy :: Proxy rowlistTail) ra rb
+    else compareRecord @rowlistTail ra rb
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     unsafeGet' = unsafeGet :: String -> Record row -> focus
     left = unsafeGet' key ra `compare` unsafeGet' key rb
 
@@ -261,4 +261,4 @@ instance ordRecord ::
   , OrdRecord list row
   ) =>
   Ord (Record row) where
-  compare = compareRecord (Proxy :: Proxy list)
+  compare = compareRecord @list

--- a/src/Data/Ord.purs
+++ b/src/Data/Ord.purs
@@ -45,7 +45,7 @@ import Type.Proxy (Proxy(..))
 -- |
 -- | **Note:** The `Number` type is not an entirely law abiding member of this
 -- | class due to the presence of `NaN`, since `NaN <= NaN` evaluates to `false`
-class Eq a <= Ord a where
+class Eq a <= Ord @a where
   compare :: a -> a -> Ordering
 
 instance ordBoolean :: Ord Boolean where
@@ -133,25 +133,25 @@ instance ordOrdering :: Ord Ordering where
   compare GT _ = GT
 
 -- | Test whether one value is _strictly less than_ another.
-lessThan :: forall a. Ord a => a -> a -> Boolean
+lessThan :: forall @a. Ord a => a -> a -> Boolean
 lessThan a1 a2 = case a1 `compare` a2 of
   LT -> true
   _ -> false
 
 -- | Test whether one value is _strictly greater than_ another.
-greaterThan :: forall a. Ord a => a -> a -> Boolean
+greaterThan :: forall @a. Ord a => a -> a -> Boolean
 greaterThan a1 a2 = case a1 `compare` a2 of
   GT -> true
   _ -> false
 
 -- | Test whether one value is _non-strictly less than_ another.
-lessThanOrEq :: forall a. Ord a => a -> a -> Boolean
+lessThanOrEq :: forall @a. Ord a => a -> a -> Boolean
 lessThanOrEq a1 a2 = case a1 `compare` a2 of
   GT -> false
   _ -> true
 
 -- | Test whether one value is _non-strictly greater than_ another.
-greaterThanOrEq :: forall a. Ord a => a -> a -> Boolean
+greaterThanOrEq :: forall @a. Ord a => a -> a -> Boolean
 greaterThanOrEq a1 a2 = case a1 `compare` a2 of
   LT -> false
   _ -> true
@@ -162,12 +162,12 @@ infixl 4 greaterThan as >
 infixl 4 greaterThanOrEq as >=
 
 -- | Compares two values by mapping them to a type with an `Ord` instance.
-comparing :: forall a b. Ord b => (a -> b) -> (a -> a -> Ordering)
+comparing :: forall @b @a. Ord b => (a -> b) -> (a -> a -> Ordering)
 comparing f x y = compare (f x) (f y)
 
 -- | Take the minimum of two values. If they are considered equal, the first
 -- | argument is chosen.
-min :: forall a. Ord a => a -> a -> a
+min :: forall @a. Ord a => a -> a -> a
 min x y =
   case compare x y of
     LT -> x
@@ -176,7 +176,7 @@ min x y =
 
 -- | Take the maximum of two values. If they are considered equal, the first
 -- | argument is chosen.
-max :: forall a. Ord a => a -> a -> a
+max :: forall @a. Ord a => a -> a -> a
 max x y =
   case compare x y of
     LT -> y
@@ -191,7 +191,7 @@ max x y =
 -- | f 5    == 5
 -- | f 15   == 10
 -- | ```
-clamp :: forall a. Ord a => a -> a -> a -> a
+clamp :: forall @a. Ord a => a -> a -> a -> a
 clamp low hi x = min hi (max low x)
 
 -- | Test whether a value is between a minimum and a maximum (inclusive).
@@ -205,7 +205,7 @@ clamp low hi x = min hi (max low x)
 -- | f 10   == true
 -- | f 15   == false
 -- | ```
-between :: forall a. Ord a => a -> a -> a -> Boolean
+between :: forall @a. Ord a => a -> a -> a -> Boolean
 between low hi x
   | x < low = false
   | x > hi = false
@@ -213,7 +213,7 @@ between low hi x
 
 -- | The absolute value function. `abs x` is defined as `if x >= zero then x
 -- | else negate x`.
-abs :: forall a. Ord a => Ring a => a -> a
+abs :: forall @a. Ord a => Ring a => a -> a
 abs x = if x >= zero then x else negate x
 
 -- | The sign function; returns `one` if the argument is positive,
@@ -221,7 +221,7 @@ abs x = if x >= zero then x else negate x
 -- | For floating point numbers with signed zeroes, when called with a zero,
 -- | this function returns the argument in order to preserve the sign.
 -- | For any `x`, we should have `signum x * abs x == x`.
-signum :: forall a. Ord a => Ring a => a -> a
+signum :: forall @a. Ord a => Ring a => a -> a
 signum x =
   if x < zero then negate one
   else if x > zero then one
@@ -235,7 +235,7 @@ instance ord1Array :: Ord1 Array where
   compare1 = compare
 
 class OrdRecord :: RL.RowList Type -> Row Type -> Constraint
-class EqRecord rowlist row <= OrdRecord rowlist row where
+class EqRecord rowlist row <= OrdRecord @rowlist @row where
   compareRecord :: Proxy rowlist -> Record row -> Record row -> Ordering
 
 instance ordRecordNil :: OrdRecord RL.Nil row where

--- a/src/Data/Reflectable.purs
+++ b/src/Data/Reflectable.purs
@@ -18,7 +18,7 @@ import Type.Proxy (Proxy(..))
 class Reflectable :: forall k. k -> Type -> Constraint
 class Reflectable @v @t | v -> t where
   -- | Reflect a type `v` to its term-level representation.
-  reflectType :: Proxy v -> t
+  reflectType :: t
 
 -- | A type class for reifiable types.
 -- |

--- a/src/Data/Reflectable.purs
+++ b/src/Data/Reflectable.purs
@@ -16,7 +16,7 @@ import Type.Proxy (Proxy(..))
 -- | * Ordering
 -- | * Symbol
 class Reflectable :: forall k. k -> Type -> Constraint
-class Reflectable v t | v -> t where
+class Reflectable @v @t | v -> t where
   -- | Reflect a type `v` to its term-level representation.
   reflectType :: Proxy v -> t
 
@@ -25,7 +25,7 @@ class Reflectable v t | v -> t where
 -- | Instances of this type class correspond to the `t` synthesized
 -- | by the compiler when solving the `Reflectable` type class.
 class Reifiable :: Type -> Constraint
-class Reifiable t
+class Reifiable @t
 
 instance Reifiable Boolean
 instance Reifiable Int
@@ -46,7 +46,7 @@ foreign import unsafeCoerce :: forall a b. a -> b
 -- | twiceOfTerm :: Int
 -- | twiceOfTerm = reifyType 21 twiceFromType
 -- | ```
-reifyType :: forall t r. Reifiable t => t -> (forall v. Reflectable v t => Proxy v -> r) -> r
+reifyType :: forall @t r. Reifiable t => t -> (forall v. Reflectable v t => Proxy v -> r) -> r
 reifyType s f = coerce f { reflectType: \_ -> s } Proxy
   where
   coerce

--- a/src/Data/Ring.purs
+++ b/src/Data/Ring.purs
@@ -58,10 +58,10 @@ foreign import numSub :: Number -> Number -> Number
 -- | implement the `Ring` instance for records.
 class RingRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class SemiringRecord rowlist row subrow <= RingRecord @rowlist @row @subrow | rowlist -> subrow where
-  subRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
+  subRecord :: Record row -> Record row -> Record subrow
 
 instance ringRecordNil :: RingRecord RL.Nil row () where
-  subRecord _ _ _ = {}
+  subRecord _ _ = {}
 
 instance ringRecordCons ::
   ( IsSymbol key
@@ -70,9 +70,9 @@ instance ringRecordCons ::
   , Ring focus
   ) =>
   RingRecord (RL.Cons key focus rowlistTail) row subrow where
-  subRecord _ ra rb = insert (get ra - get rb) tail
+  subRecord ra rb = insert (get ra - get rb) tail
     where
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     get = unsafeGet key :: Record row -> focus
-    tail = subRecord (Proxy :: Proxy rowlistTail) ra rb
+    tail = subRecord @rowlistTail ra rb

--- a/src/Data/Ring.purs
+++ b/src/Data/Ring.purs
@@ -24,7 +24,7 @@ import Type.Proxy (Proxy(..))
 -- |
 -- | - Additive inverse: `a - a = zero`
 -- | - Compatibility of `sub` and `negate`: `a - b = a + (zero - b)`
-class Semiring a <= Ring a where
+class Semiring a <= Ring @a where
   sub :: a -> a -> a
 
 infixl 6 sub as -
@@ -48,7 +48,7 @@ instance ringRecord :: (RL.RowToList row list, RingRecord list row row) => Ring 
   sub = subRecord (Proxy :: Proxy list)
 
 -- | `negate x` can be used as a shorthand for `zero - x`.
-negate :: forall a. Ring a => a -> a
+negate :: forall @a. Ring a => a -> a
 negate a = zero - a
 
 foreign import intSub :: Int -> Int -> Int
@@ -57,7 +57,7 @@ foreign import numSub :: Number -> Number -> Number
 -- | A class for records where all fields have `Ring` instances, used to
 -- | implement the `Ring` instance for records.
 class RingRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
-class SemiringRecord rowlist row subrow <= RingRecord rowlist row subrow | rowlist -> subrow where
+class SemiringRecord rowlist row subrow <= RingRecord @rowlist @row @subrow | rowlist -> subrow where
   subRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
 
 instance ringRecordNil :: RingRecord RL.Nil row () where

--- a/src/Data/Semigroup.purs
+++ b/src/Data/Semigroup.purs
@@ -64,10 +64,10 @@ foreign import concatArray :: forall a. Array a -> Array a -> Array a
 -- | implement the `Semigroup` instance for records.
 class SemigroupRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class SemigroupRecord @rowlist @row @subrow | rowlist -> subrow where
-  appendRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
+  appendRecord :: Record row -> Record row -> Record subrow
 
 instance semigroupRecordNil :: SemigroupRecord RL.Nil row () where
-  appendRecord _ _ _ = {}
+  appendRecord _ _ = {}
 
 instance semigroupRecordCons ::
   ( IsSymbol key
@@ -76,9 +76,9 @@ instance semigroupRecordCons ::
   , Semigroup focus
   ) =>
   SemigroupRecord (RL.Cons key focus rowlistTail) row subrow where
-  appendRecord _ ra rb = insert (get ra <> get rb) tail
+  appendRecord ra rb = insert (get ra <> get rb) tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     get = unsafeGet key :: Record row -> focus
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
-    tail = appendRecord (Proxy :: Proxy rowlistTail) ra rb
+    tail = appendRecord @rowlistTail ra rb

--- a/src/Data/Semigroup.purs
+++ b/src/Data/Semigroup.purs
@@ -31,7 +31,7 @@ import Type.Proxy (Proxy(..))
 -- | wrapping the values in one of the two newtypes below:
 -- | 1. `First` - Use the first argument every time: `append first _ = first`.
 -- | 2. `Last` - Use the last argument every time: `append _ last = last`.
-class Semigroup a where
+class Semigroup @a where
   append :: a -> a -> a
 
 infixr 5 append as <>
@@ -63,7 +63,7 @@ foreign import concatArray :: forall a. Array a -> Array a -> Array a
 -- | A class for records where all fields have `Semigroup` instances, used to
 -- | implement the `Semigroup` instance for records.
 class SemigroupRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
-class SemigroupRecord rowlist row subrow | rowlist -> subrow where
+class SemigroupRecord @rowlist @row @subrow | rowlist -> subrow where
   appendRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
 
 instance semigroupRecordNil :: SemigroupRecord RL.Nil row () where

--- a/src/Data/Semigroup/First.purs
+++ b/src/Data/Semigroup/First.purs
@@ -10,7 +10,7 @@ import Data.Ord (class Ord1)
 -- | ``` purescript
 -- | First x <> First y == First x
 -- | ```
-newtype First a = First a
+newtype First @a = First a
 
 derive newtype instance eqFirst :: Eq a => Eq (First a)
 derive instance eq1First :: Eq1 First

--- a/src/Data/Semigroup/Last.purs
+++ b/src/Data/Semigroup/Last.purs
@@ -10,7 +10,7 @@ import Data.Ord (class Ord1)
 -- | ``` purescript
 -- | Last x <> Last y == Last y
 -- | ```
-newtype Last a = Last a
+newtype Last @a = Last a
 
 derive newtype instance eqLast :: Eq a => Eq (Last a)
 derive instance eq1Last :: Eq1 Last

--- a/src/Data/Semiring.purs
+++ b/src/Data/Semiring.purs
@@ -81,10 +81,10 @@ instance semiringProxy :: Semiring (Proxy a) where
   zero = Proxy
 
 instance semiringRecord :: (RL.RowToList row list, SemiringRecord list row row) => Semiring (Record row) where
-  add = addRecord (Proxy :: Proxy list)
-  mul = mulRecord (Proxy :: Proxy list)
-  one = oneRecord (Proxy :: Proxy list) (Proxy :: Proxy row)
-  zero = zeroRecord (Proxy :: Proxy list) (Proxy :: Proxy row)
+  add = addRecord @list
+  mul = mulRecord @list
+  one = oneRecord @list @row
+  zero = zeroRecord @list @row
 
 foreign import intAdd :: Int -> Int -> Int
 foreign import intMul :: Int -> Int -> Int
@@ -95,16 +95,16 @@ foreign import numMul :: Number -> Number -> Number
 -- | implement the `Semiring` instance for records.
 class SemiringRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
 class SemiringRecord @rowlist @row @subrow | rowlist -> subrow where
-  addRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
-  mulRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
-  oneRecord :: Proxy rowlist -> Proxy row -> Record subrow
-  zeroRecord :: Proxy rowlist -> Proxy row -> Record subrow
+  addRecord :: Record row -> Record row -> Record subrow
+  mulRecord :: Record row -> Record row -> Record subrow
+  oneRecord :: Record subrow
+  zeroRecord :: Record subrow
 
 instance semiringRecordNil :: SemiringRecord RL.Nil row () where
-  addRecord _ _ _ = {}
-  mulRecord _ _ _ = {}
-  oneRecord _ _ = {}
-  zeroRecord _ _ = {}
+  addRecord _ _ = {}
+  mulRecord _ _ = {}
+  oneRecord = {}
+  zeroRecord = {}
 
 instance semiringRecordCons ::
   ( IsSymbol key
@@ -113,28 +113,28 @@ instance semiringRecordCons ::
   , Semiring focus
   ) =>
   SemiringRecord (RL.Cons key focus rowlistTail) row subrow where
-  addRecord _ ra rb = insert (get ra + get rb) tail
+  addRecord ra rb = insert (get ra + get rb) tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     get = unsafeGet key :: Record row -> focus
-    tail = addRecord (Proxy :: Proxy rowlistTail) ra rb
+    tail = addRecord @rowlistTail ra rb
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
 
-  mulRecord _ ra rb = insert (get ra * get rb) tail
+  mulRecord ra rb = insert (get ra * get rb) tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     get = unsafeGet key :: Record row -> focus
-    tail = mulRecord (Proxy :: Proxy rowlistTail) ra rb
+    tail = mulRecord @rowlistTail ra rb
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
 
-  oneRecord _ _ = insert one tail
+  oneRecord = insert one tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
-    tail = oneRecord (Proxy :: Proxy rowlistTail) (Proxy :: Proxy row)
+    key = reflectSymbol @key
+    tail = oneRecord @rowlistTail @row
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow
 
-  zeroRecord _ _ = insert zero tail
+  zeroRecord = insert zero tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
-    tail = zeroRecord (Proxy :: Proxy rowlistTail) (Proxy :: Proxy row)
+    key = reflectSymbol @key
+    tail = zeroRecord @rowlistTail @row
     insert = unsafeSet key :: focus -> Record subrowTail -> Record subrow

--- a/src/Data/Semiring.purs
+++ b/src/Data/Semiring.purs
@@ -41,7 +41,7 @@ import Type.Proxy (Proxy(..))
 -- | members of this class hierarchy due to the potential for arithmetic
 -- | overflows, and in the case of `Number`, the presence of `NaN` and
 -- | `Infinity` values. The behaviour is unspecified in these cases.
-class Semiring a where
+class Semiring @a where
   add :: a -> a -> a
   zero :: a
   mul :: a -> a -> a
@@ -94,7 +94,7 @@ foreign import numMul :: Number -> Number -> Number
 -- | A class for records where all fields have `Semiring` instances, used to
 -- | implement the `Semiring` instance for records.
 class SemiringRecord :: RL.RowList Type -> Row Type -> Row Type -> Constraint
-class SemiringRecord rowlist row subrow | rowlist -> subrow where
+class SemiringRecord @rowlist @row @subrow | rowlist -> subrow where
   addRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
   mulRecord :: Proxy rowlist -> Record row -> Record row -> Record subrow
   oneRecord :: Proxy rowlist -> Proxy row -> Record subrow

--- a/src/Data/Show.purs
+++ b/src/Data/Show.purs
@@ -55,10 +55,10 @@ instance showRecord ::
 -- | implement the `Show` instance for records.
 class ShowRecordFields :: RL.RowList Type -> Row Type -> Constraint
 class ShowRecordFields @rowlist @row where
-  showRecordFields :: Proxy rowlist -> Record row -> Array String
+  showRecordFields :: Record row -> Array String
 
 instance showRecordFieldsNil :: ShowRecordFields RL.Nil row where
-  showRecordFields _ _ = []
+  showRecordFields _ = []
 
 instance showRecordFieldsCons ::
   ( IsSymbol key
@@ -66,11 +66,11 @@ instance showRecordFieldsCons ::
   , Show focus
   ) =>
   ShowRecordFields (RL.Cons key focus rowlistTail) row where
-  showRecordFields _ record = cons (intercalate ": " [ key, show focus ]) tail
+  showRecordFields record = cons (intercalate ": " [ key, show focus ]) tail
     where
-    key = reflectSymbol (Proxy :: Proxy key)
+    key = reflectSymbol @key
     focus = unsafeGet key record :: focus
-    tail = showRecordFields (Proxy :: Proxy rowlistTail) record
+    tail = showRecordFields @rowlistTail record
 
 foreign import showIntImpl :: Int -> String
 foreign import showNumberImpl :: Number -> String

--- a/src/Data/Show.purs
+++ b/src/Data/Show.purs
@@ -17,7 +17,7 @@ import Type.Proxy (Proxy(..))
 -- | While not required, it is recommended that for any expression `x`, the
 -- | string `show x` be executable PureScript code which evaluates to the same
 -- | value as the expression `x`.
-class Show a where
+class Show @a where
   show :: a -> String
 
 instance showBoolean :: Show Boolean where
@@ -54,7 +54,7 @@ instance showRecord ::
 -- | A class for records where all fields have `Show` instances, used to
 -- | implement the `Show` instance for records.
 class ShowRecordFields :: RL.RowList Type -> Row Type -> Constraint
-class ShowRecordFields rowlist row where
+class ShowRecordFields @rowlist @row where
   showRecordFields :: Proxy rowlist -> Record row -> Array String
 
 instance showRecordFieldsNil :: ShowRecordFields RL.Nil row where

--- a/src/Data/Symbol.purs
+++ b/src/Data/Symbol.purs
@@ -7,7 +7,8 @@ module Data.Symbol
 import Type.Proxy (Proxy(..))
 
 -- | A class for known symbols
-class IsSymbol (@sym :: Symbol) where
+class IsSymbol :: Symbol -> Constraint
+class IsSymbol @sym where
   reflectSymbol :: String
 
 -- local definition for use in `reifySymbol`

--- a/src/Data/Symbol.purs
+++ b/src/Data/Symbol.purs
@@ -7,7 +7,7 @@ module Data.Symbol
 import Type.Proxy (Proxy(..))
 
 -- | A class for known symbols
-class IsSymbol (sym :: Symbol) where
+class IsSymbol (@sym :: Symbol) where
   reflectSymbol :: Proxy sym -> String
 
 -- local definition for use in `reifySymbol`

--- a/src/Data/Symbol.purs
+++ b/src/Data/Symbol.purs
@@ -8,17 +8,16 @@ import Type.Proxy (Proxy(..))
 
 -- | A class for known symbols
 class IsSymbol (@sym :: Symbol) where
-  reflectSymbol :: Proxy sym -> String
+  reflectSymbol :: String
 
 -- local definition for use in `reifySymbol`
 foreign import unsafeCoerce :: forall a b. a -> b
 
 reifySymbol :: forall r. String -> (forall sym. IsSymbol sym => Proxy sym -> r) -> r
-reifySymbol s f = coerce f { reflectSymbol: \_ -> s } Proxy
+reifySymbol s f = coerce f { reflectSymbol: s }
   where
   coerce
-    :: (forall sym1. IsSymbol sym1 => Proxy sym1 -> r)
-    -> { reflectSymbol :: Proxy "" -> String }
-    -> Proxy ""
+    :: (forall sym1. IsSymbol sym1 => r)
+    -> { reflectSymbol :: String }
     -> r
   coerce = unsafeCoerce


### PR DESCRIPTION
**Description of the change**

Updates most type variables to support visible type applications. I'm not sure we want to do this as liberally as I have done, but it should reveal all we could do.

Also drops unneeded `Proxy` args in many record-related functions now that such information can be passed via visible type applications.

Blocked by https://github.com/purescript/purescript/pull/4235

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
