### PR TITLE
Fix String show instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
 - Replaced polymorphic proxies with monomorphic `Proxy` (#281, #288 by @JordanMartinez)
 - Fix `signum zero` to return `zero` (#280 by @JordanMartinez)
 - Fix `Show` instance on records with duplicate labels by adding `Nub` constraint (#269 by @JordanMartinez)
+- Fix `Show` instance for String (#270 by @JordanMartinez)
 
 New features:
 - Added the `Data.Reflectable` module for type reflection (#289 by @PureFunctor)

--- a/src/Data/Show.js
+++ b/src/Data/Show.js
@@ -24,28 +24,36 @@ export const showCharImpl = function (c) {
   return c === "'" || c === "\\" ? "'\\" + c + "'" : "'" + c + "'";
 };
 
+const showHex = function(width, c) {
+  return Number(c).toString(16).padStart(width, "0");
+};
+
 export const showStringImpl = function (s) {
-  var l = s.length;
-  return "\"" + s.replace(
-    /[\0-\x1F\x7F"\\]/g, // eslint-disable-line no-control-regex
-    function (c, i) {
-      switch (c) {
-        case "\"":
-        case "\\":
-          return "\\" + c;
-        case "\x07": return "\\a";
-        case "\b": return "\\b";
-        case "\f": return "\\f";
-        case "\n": return "\\n";
-        case "\r": return "\\r";
-        case "\t": return "\\t";
-        case "\v": return "\\v";
+  var str = "";
+  Array.from(s, function(str) { return str.charCodeAt(0); })
+    .forEach(function (cp) {
+      if (cp > 0xFF) {
+        str += "\\u" + showHex(4, cp);
+      } else if (cp > 0x7E || cp < 0x20) {
+        str += "\\x" + showHex(2, cp);
+      } else {
+        const ch = String.fromCodePoint(cp);
+        switch (ch) {
+          case "\b": str += "\\b"; break;
+          case "\t": str += "\\t"; break;
+          case "\n": str += "\\n"; break;
+          case "\v": str += "\\v"; break;
+          case "\f": str += "\\f"; break;
+          case "\r": str += "\\r"; break;
+          case "\"":
+          case "\\":
+            str += "\\" + ch;  break;
+          default:
+            str += ch;  break;
+        }
       }
-      var k = i + 1;
-      var empty = k < l && s[k] >= "0" && s[k] <= "9" ? "\\&" : "";
-      return "\\" + c.charCodeAt(0).toString(10) + empty;
-    }
-  ) + "\"";
+    });
+  return "\"" + str + "\"";
 };
 
 export const showArrayImpl = function (f) {

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -13,6 +13,7 @@ import Type.Proxy (Proxy(..))
 main :: AlmostEff
 main = do
     testNumberShow show
+    testStringShow
     testOrderings
     testOrdUtils
     testIntDivMod
@@ -24,6 +25,10 @@ main = do
     testSignum
 
 foreign import testNumberShow :: (Number -> String) -> AlmostEff
+
+testStringShow :: AlmostEff
+testStringShow = do
+  assert "JS string implementation should match compiler's" $ (show "\x0000001") == (reflectType (Proxy :: Proxy "\x0000001"))
 
 testOrd :: forall a. Ord a => Show a => a -> a -> Ordering -> AlmostEff
 testOrd x y ord =


### PR DESCRIPTION
**Description of the change**

Fixes #258 based on [`prettyPrintStringJs`](https://github.com/purescript/purescript/blob/master/lib/purescript-cst/src/Language/PureScript/PSString.hs#L195-L213). I'm not sure whether this implementation is correct or the best.

Also, the test does not currently pass.

```console
# repl
> "\x0000001"
"\x001"
```

CC @MonoidMusician

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
