### PR TITLE
Adds yoneda-inspired thunks for Category and Monoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-	"private": true,
-	"scripts": {
-		"clean": "rimraf output && rimraf .pulp-cache",
-		"build": "eslint src && pulp build -- --censor-lib --strict",
-		"test": "pulp test"
-	},
-	"devDependencies": {
-		"eslint": "^7.15.0",
-		"purescript-psa": "^0.8.2",
-		"pulp": "^16.0.0-0",
-		"rimraf": "^3.0.2"
-	}
+  "private": true,
+  "scripts": {
+    "clean": "rimraf output && rimraf .pulp-cache",
+    "build": "eslint src && pulp build -- --censor-lib --strict",
+    "test": "pulp test"
+  },
+  "devDependencies": {
+    "eslint": "^7.15.0",
+    "purescript-psa": "^0.8.2",
+    "pulp": "^16.0.0-0",
+    "rimraf": "^3.0.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "eslint": "^7.15.0",
     "purescript-psa": "^0.8.2",
-    "pulp": "^16.0.0-0",
+    "pulp": "16.0.0-0",
     "rimraf": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,17 +1,14 @@
 {
-  "private": true,
-  "scripts": {
-    "clean": "rimraf output && rimraf .pulp-cache",
-    "build": "eslint src && pulp build -- --censor-lib --strict",
-    "test": "pulp test"
-  },
-  "devDependencies": {
-    "eslint": "^7.15.0",
-    "pulp": "^16.0.0-0",
-    "purescript-psa": "^0.8.2",
-    "rimraf": "^3.0.2"
-  },
-  "dependencies": {
-    "purescript": "^0.15.0"
-  }
+	"private": true,
+	"scripts": {
+		"clean": "rimraf output && rimraf .pulp-cache",
+		"build": "eslint src && pulp build -- --censor-lib --strict",
+		"test": "pulp test"
+	},
+	"devDependencies": {
+		"eslint": "^7.15.0",
+		"purescript-psa": "^0.8.2",
+		"pulp": "^16.0.0-0",
+		"rimraf": "^3.0.2"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
   },
   "devDependencies": {
     "eslint": "^7.15.0",
+    "pulp": "^16.0.0-0",
     "purescript-psa": "^0.8.2",
-    "pulp": "16.0.0-0",
     "rimraf": "^3.0.2"
+  },
+  "dependencies": {
+    "purescript": "^0.15.0"
   }
 }

--- a/src/Control/Category.purs
+++ b/src/Control/Category.purs
@@ -2,6 +2,7 @@ module Control.Category
   ( class Category
   , identity
   , module Control.Semigroupoid
+  , cayo
   ) where
 
 import Control.Semigroupoid (class Semigroupoid, compose, (<<<), (>>>))
@@ -20,3 +21,7 @@ class Semigroupoid a <= Category a where
 
 instance categoryFn :: Category (->) where
   identity x = x
+
+-- | Thunks a closure with the identity of a category to retrieve its value.
+cayo :: forall p a b. Category p => (p a a -> b) -> b
+cayo f = f identity

--- a/src/Data/Monoid.purs
+++ b/src/Data/Monoid.purs
@@ -6,6 +6,7 @@ module Data.Monoid
   , module Data.Semigroup
   , class MonoidRecord
   , memptyRecord
+  , moyo
   ) where
 
 import Data.Boolean (otherwise)
@@ -96,6 +97,10 @@ power x = go
 guard :: forall m. Monoid m => Boolean -> m -> m
 guard true a = a
 guard false _ = mempty
+
+-- | Thunks a closure with the mempty of a monoid to retrieve its value.
+moyo :: forall m a. Monoid m => (m -> a) -> a
+moyo f = f mempty
 
 -- | A class for records where all fields have `Monoid` instances, used to
 -- | implement the `Monoid` instance for records.


### PR DESCRIPTION
**Description of the change**

I've written these functions 3-4 times in various repos here and there, and I think they're of enough utility to be in the prelude.

Both of them are yoneda-inspired and basically fish out a value from a closure. For example, `cayo` can be used with profunctor lenses, ie `t = cayo (_2 <<< _2 <<< _2) (1 /\ 2 /\ 3 /\ 4)`.

If folks are ok with this, lemme know and I'll make the relevant changelog entries.

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
