### PR TITLE
Use `var` instead of `const`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Replace `const` with `var`, since esbuild cannot lower `const` and `let` to `var` at the moment, preventing transpiling to ES5 using esbuild (#296 by @mhmdanas)
 
 Other improvements:
 

--- a/src/Control/Apply.js
+++ b/src/Control/Apply.js
@@ -1,4 +1,4 @@
-export const arrayApply = function (fs) {
+export var arrayApply = function (fs) {
   return function (xs) {
     var l = fs.length;
     var k = xs.length;

--- a/src/Control/Bind.js
+++ b/src/Control/Bind.js
@@ -1,4 +1,4 @@
-export const arrayBind = function (arr) {
+export var arrayBind = function (arr) {
   return function (f) {
     var result = [];
     for (var i = 0, l = arr.length; i < l; i++) {

--- a/src/Data/Bounded.js
+++ b/src/Data/Bounded.js
@@ -1,8 +1,8 @@
-export const topInt = 2147483647;
-export const bottomInt = -2147483648;
+export var topInt = 2147483647;
+export var bottomInt = -2147483648;
 
-export const topChar = String.fromCharCode(65535);
-export const bottomChar = String.fromCharCode(0);
+export var topChar = String.fromCharCode(65535);
+export var bottomChar = String.fromCharCode(0);
 
-export const topNumber = Number.POSITIVE_INFINITY;
-export const bottomNumber = Number.NEGATIVE_INFINITY;
+export var topNumber = Number.POSITIVE_INFINITY;
+export var bottomNumber = Number.NEGATIVE_INFINITY;

--- a/src/Data/Eq.js
+++ b/src/Data/Eq.js
@@ -4,13 +4,13 @@ var refEq = function (r1) {
   };
 };
 
-export const eqBooleanImpl = refEq;
-export const eqIntImpl = refEq;
-export const eqNumberImpl = refEq;
-export const eqCharImpl = refEq;
-export const eqStringImpl = refEq;
+export var eqBooleanImpl = refEq;
+export var eqIntImpl = refEq;
+export var eqNumberImpl = refEq;
+export var eqCharImpl = refEq;
+export var eqStringImpl = refEq;
 
-export const eqArrayImpl = function (f) {
+export var eqArrayImpl = function (f) {
   return function (xs) {
     return function (ys) {
       if (xs.length !== ys.length) return false;

--- a/src/Data/EuclideanRing.js
+++ b/src/Data/EuclideanRing.js
@@ -1,17 +1,17 @@
-export const intDegree = function (x) {
+export var intDegree = function (x) {
   return Math.min(Math.abs(x), 2147483647);
 };
 
 // See the Euclidean definition in
 // https://en.m.wikipedia.org/wiki/Modulo_operation.
-export const intDiv = function (x) {
+export var intDiv = function (x) {
   return function (y) {
     if (y === 0) return 0;
     return y > 0 ? Math.floor(x / y) : -Math.floor(x / -y);
   };
 };
 
-export const intMod = function (x) {
+export var intMod = function (x) {
   return function (y) {
     if (y === 0) return 0;
     var yy = Math.abs(y);
@@ -19,7 +19,7 @@ export const intMod = function (x) {
   };
 };
 
-export const numDiv = function (n1) {
+export var numDiv = function (n1) {
   return function (n2) {
     return n1 / n2;
   };

--- a/src/Data/Functor.js
+++ b/src/Data/Functor.js
@@ -1,4 +1,4 @@
-export const arrayMap = function (f) {
+export var arrayMap = function (f) {
   return function (arr) {
     var l = arr.length;
     var result = new Array(l);

--- a/src/Data/HeytingAlgebra.js
+++ b/src/Data/HeytingAlgebra.js
@@ -1,15 +1,15 @@
-export const boolConj = function (b1) {
+export var boolConj = function (b1) {
   return function (b2) {
     return b1 && b2;
   };
 };
 
-export const boolDisj = function (b1) {
+export var boolDisj = function (b1) {
   return function (b2) {
     return b1 || b2;
   };
 };
 
-export const boolNot = function (b) {
+export var boolNot = function (b) {
   return !b;
 };

--- a/src/Data/Ord.js
+++ b/src/Data/Ord.js
@@ -10,13 +10,13 @@ var unsafeCompareImpl = function (lt) {
   };
 };
 
-export const ordBooleanImpl = unsafeCompareImpl;
-export const ordIntImpl = unsafeCompareImpl;
-export const ordNumberImpl = unsafeCompareImpl;
-export const ordStringImpl = unsafeCompareImpl;
-export const ordCharImpl = unsafeCompareImpl;
+export var ordBooleanImpl = unsafeCompareImpl;
+export var ordIntImpl = unsafeCompareImpl;
+export var ordNumberImpl = unsafeCompareImpl;
+export var ordStringImpl = unsafeCompareImpl;
+export var ordCharImpl = unsafeCompareImpl;
 
-export const ordArrayImpl = function (f) {
+export var ordArrayImpl = function (f) {
   return function (xs) {
     return function (ys) {
       var i = 0;

--- a/src/Data/Reflectable.js
+++ b/src/Data/Reflectable.js
@@ -1,5 +1,5 @@
 // module Data.Reflectable
 
-export const unsafeCoerce = function (arg) {
+export var unsafeCoerce = function (arg) {
   return arg;
 };

--- a/src/Data/Ring.js
+++ b/src/Data/Ring.js
@@ -1,11 +1,11 @@
-export const intSub = function (x) {
+export var intSub = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x - y | 0;
   };
 };
 
-export const numSub = function (n1) {
+export var numSub = function (n1) {
   return function (n2) {
     return n1 - n2;
   };

--- a/src/Data/Semigroup.js
+++ b/src/Data/Semigroup.js
@@ -1,10 +1,10 @@
-export const concatString = function (s1) {
+export var concatString = function (s1) {
   return function (s2) {
     return s1 + s2;
   };
 };
 
-export const concatArray = function (xs) {
+export var concatArray = function (xs) {
   return function (ys) {
     if (xs.length === 0) return ys;
     if (ys.length === 0) return xs;

--- a/src/Data/Semiring.js
+++ b/src/Data/Semiring.js
@@ -1,24 +1,24 @@
-export const intAdd = function (x) {
+export var intAdd = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x + y | 0;
   };
 };
 
-export const intMul = function (x) {
+export var intMul = function (x) {
   return function (y) {
     /* jshint bitwise: false */
     return x * y | 0;
   };
 };
 
-export const numAdd = function (n1) {
+export var numAdd = function (n1) {
   return function (n2) {
     return n1 + n2;
   };
 };
 
-export const numMul = function (n1) {
+export var numMul = function (n1) {
   return function (n2) {
     return n1 * n2;
   };

--- a/src/Data/Show.js
+++ b/src/Data/Show.js
@@ -1,13 +1,13 @@
-export const showIntImpl = function (n) {
+export var showIntImpl = function (n) {
   return n.toString();
 };
 
-export const showNumberImpl = function (n) {
+export var showNumberImpl = function (n) {
   var str = n.toString();
   return isNaN(str + ".0") ? str : str + ".0";
 };
 
-export const showCharImpl = function (c) {
+export var showCharImpl = function (c) {
   var code = c.charCodeAt(0);
   if (code < 0x20 || code === 0x7F) {
     switch (c) {
@@ -24,7 +24,7 @@ export const showCharImpl = function (c) {
   return c === "'" || c === "\\" ? "'\\" + c + "'" : "'" + c + "'";
 };
 
-export const showStringImpl = function (s) {
+export var showStringImpl = function (s) {
   var l = s.length;
   return "\"" + s.replace(
     /[\0-\x1F\x7F"\\]/g, // eslint-disable-line no-control-regex
@@ -48,7 +48,7 @@ export const showStringImpl = function (s) {
   ) + "\"";
 };
 
-export const showArrayImpl = function (f) {
+export var showArrayImpl = function (f) {
   return function (xs) {
     var ss = [];
     for (var i = 0, l = xs.length; i < l; i++) {
@@ -58,13 +58,13 @@ export const showArrayImpl = function (f) {
   };
 };
 
-export const cons = function (head) {
+export var cons = function (head) {
   return function (tail) {
     return [head].concat(tail);
   };
 };
 
-export const intercalate = function (separator) {
+export var intercalate = function (separator) {
   return function (xs) {
     return xs.join(separator);
   };

--- a/src/Data/Show/Generic.js
+++ b/src/Data/Show/Generic.js
@@ -1,4 +1,4 @@
-export const intercalate = function (separator) {
+export var intercalate = function (separator) {
   return function (xs) {
     return xs.join(separator);
   };

--- a/src/Data/Symbol.js
+++ b/src/Data/Symbol.js
@@ -1,6 +1,6 @@
 // module Data.Symbol
 
-export const unsafeCoerce = function (arg) {
+export var unsafeCoerce = function (arg) {
   return arg;
 };
 

--- a/src/Data/Unit.js
+++ b/src/Data/Unit.js
@@ -1,1 +1,1 @@
-export const unit = undefined;
+export var unit = undefined;

--- a/src/Record/Unsafe.js
+++ b/src/Record/Unsafe.js
@@ -1,16 +1,16 @@
-export const unsafeHas = function (label) {
+export var unsafeHas = function (label) {
   return function (rec) {
     return {}.hasOwnProperty.call(rec, label);
   };
 };
 
-export const unsafeGet = function (label) {
+export var unsafeGet = function (label) {
   return function (rec) {
     return rec[label];
   };
 };
 
-export const unsafeSet = function (label) {
+export var unsafeSet = function (label) {
   return function (value) {
     return function (rec) {
       var copy = {};
@@ -25,7 +25,7 @@ export const unsafeSet = function (label) {
   };
 };
 
-export const unsafeDelete = function (label) {
+export var unsafeDelete = function (label) {
   return function (rec) {
     var copy = {};
     for (var key in rec) {


### PR DESCRIPTION
**Description of the change**

Replace `const` with `var`, since esbuild cannot lower `const` and `let` to `var` at the moment, preventing transpiling to ES5.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
