### PR TITLE
Clarify relationship between Ord and Eq by updating the antisymmetry law

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Documentation: Clarify relationship between `Ord` and `Eq` (#298 by @JamieBallingall)
 
 ## [v6.0.0](https://github.com/purescript/purescript-prelude/releases/tag/v6.0.0) - 2022-04-27
 

--- a/src/Data/Ord.purs
+++ b/src/Data/Ord.purs
@@ -40,7 +40,7 @@ import Type.Proxy (Proxy(..))
 -- | `Ord` instances should satisfy the laws of total orderings:
 -- |
 -- | - Reflexivity: `a <= a`
--- | - Antisymmetry: if `a <= b` and `b <= a` then `a = b`
+-- | - Antisymmetry: if `a <= b` and `b <= a` then `a == b`
 -- | - Transitivity: if `a <= b` and `b <= c` then `a <= c`
 -- |
 -- | **Note:** The `Number` type is not an entirely law abiding member of this


### PR DESCRIPTION
Change "=" to "==" in antisymmetry law comment to better show the connection between Ord and Eq. Closes issue #174.
---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [X] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation
- [NA] Added a test for the contribution (if applicable)
