### PR TITLE
Update Reflexivity law of Ord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Documentation: Further clarify relationship between `Ord` and `Eq` (#301 by @JamieBallingall)
 
 ## [v6.0.1](https://github.com/purescript/purescript-prelude/releases/tag/v6.0.1) - 2022-08-18
 

--- a/src/Data/Ord.purs
+++ b/src/Data/Ord.purs
@@ -39,7 +39,7 @@ import Type.Proxy (Proxy(..))
 -- |
 -- | `Ord` instances should satisfy the laws of total orderings:
 -- |
--- | - Reflexivity: `a <= a`
+-- | - Reflexivity: if `a == b` then `a <= b`
 -- | - Antisymmetry: if `a <= b` and `b <= a` then `a == b`
 -- | - Transitivity: if `a <= b` and `b <= c` then `a <= c`
 -- |


### PR DESCRIPTION
**Description of the change**

Fixes #300 by updating the Reflexivity law of `Ord` to read:
```
-- | - Reflexivity: if `a == b` then `a <= b`
```
which better connects `Ord` to `Eq` and eliminates an unintuitive case as described in the issue.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [X] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation
- [X] Added a test for the contribution (if applicable)
