### PR TITLE
fixes #309: call stack exceeded in Control.Bind.Bind instance for Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- call stack exceeded in Control.Bind.Bind instance for Array (#311 by @michaelficarra)
 
 Other improvements:
 

--- a/src/Control/Bind.js
+++ b/src/Control/Bind.js
@@ -1,8 +1,16 @@
+var APPLY_CHUNK_SIZE = 10e3;
+var push = Function.prototype.apply.bind(Array.prototype.push);
+
 export const arrayBind = function (arr) {
   return function (f) {
     var result = [];
     for (var i = 0, l = arr.length; i < l; i++) {
-      Array.prototype.push.apply(result, f(arr[i]));
+      var subArr = f(arr[i]);
+      while (subArr.length > APPLY_CHUNK_SIZE) {
+        push(result, subArr.slice(0, APPLY_CHUNK_SIZE);
+        subArr = subArr.slice(APPLY_CHUNK_SIZE);
+      }
+      push(result, subArr);
     }
     return result;
   };


### PR DESCRIPTION
**Description of the change**

Fixes #309 by batching the arguments passed to `Array.prototype.push` by `Function.prototype.apply`. I chose 10,000 for the batch size because it's definitely in the safe range for major implementations while still being large enough to not have much effect on performance.

I couldn't find where the tests for Control.Bind live so I didn't add a test.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [X] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
