### PR TITLE
Add lazily evaluated versions of the conditional functions for applicatives and monads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Breaking changes:
 
 New features:
 
+- Add lazily evaluated versions of the conditional functions for applicatives
+  and monads ifM', when', whenM', unless' and unlessM'
+
 Bugfixes:
 
 Other improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Breaking changes:
 New features:
 
 - Add lazily evaluated versions of the conditional functions for applicatives
-  and monads ifM', when', whenM', unless' and unlessM'
+  and monads ifM', when', whenM', unless' and unlessM' (#313)
 
 Bugfixes:
 

--- a/src/Control/Applicative.purs
+++ b/src/Control/Applicative.purs
@@ -3,14 +3,19 @@ module Control.Applicative
   , pure
   , liftA1
   , unless
+  , unless'
   , when
+  , when'
   , module Control.Apply
   , module Data.Functor
   ) where
 
 import Control.Apply (class Apply, apply, (*>), (<*), (<*>))
+import Control.Category ((<<<))
 
+import Data.Boolean (otherwise)
 import Data.Functor (class Functor, map, void, ($>), (<#>), (<$), (<$>))
+import Data.HeytingAlgebra (not)
 import Data.Unit (Unit, unit)
 import Type.Proxy (Proxy(..))
 
@@ -64,7 +69,14 @@ when :: forall m. Applicative m => Boolean -> m Unit -> m Unit
 when true m = m
 when false _ = pure unit
 
+-- | Perform an applicative action lazily when a condition is true.
+when' :: forall m a. Applicative m => (a -> Boolean) -> (a -> m Unit) -> a -> m Unit
+when' f m a = if f a then m a else pure unit
+
 -- | Perform an applicative action unless a condition is true.
 unless :: forall m. Applicative m => Boolean -> m Unit -> m Unit
-unless false m = m
-unless true _ = pure unit
+unless = when <<< not
+
+-- | Perform an applicative action lazily unless a condition is true.
+unless' :: forall m a. Applicative m => (a -> Boolean) -> (a -> m Unit) -> a -> m Unit
+unless' = when' <<< not

--- a/src/Control/Applicative.purs
+++ b/src/Control/Applicative.purs
@@ -13,7 +13,6 @@ module Control.Applicative
 import Control.Apply (class Apply, apply, (*>), (<*), (<*>))
 import Control.Category ((<<<))
 
-import Data.Boolean (otherwise)
 import Data.Functor (class Functor, map, void, ($>), (<#>), (<$), (<$>))
 import Data.HeytingAlgebra (not)
 import Data.Unit (Unit, unit)
@@ -69,7 +68,7 @@ when :: forall m. Applicative m => Boolean -> m Unit -> m Unit
 when true m = m
 when false _ = pure unit
 
--- | Perform an applicative action lazily when a condition is true.
+-- | Construct an applicative action when a condition is true.
 when' :: forall m a. Applicative m => (a -> Boolean) -> (a -> m Unit) -> a -> m Unit
 when' f m a = if f a then m a else pure unit
 
@@ -77,6 +76,6 @@ when' f m a = if f a then m a else pure unit
 unless :: forall m. Applicative m => Boolean -> m Unit -> m Unit
 unless = when <<< not
 
--- | Perform an applicative action lazily unless a condition is true.
+-- | Construct an applicative action unless a condition is true.
 unless' :: forall m a. Applicative m => (a -> Boolean) -> (a -> m Unit) -> a -> m Unit
 unless' = when' <<< not

--- a/src/Control/Bind.purs
+++ b/src/Control/Bind.purs
@@ -12,6 +12,7 @@ module Control.Bind
   , composeKleisliFlipped
   , (<=<)
   , ifM
+  , ifM'
   , module Data.Functor
   , module Control.Apply
   , module Control.Applicative
@@ -148,3 +149,23 @@ infixr 1 composeKleisliFlipped as <=<
 -- | ```
 ifM :: forall a m. Bind m => m Boolean -> m a -> m a -> m a
 ifM cond t f = cond >>= \cond' -> if cond' then t else f
+
+-- | Similar to `ifM` but for use in cases where one of the monadic actions may
+-- | be expensive to compute or be responsible for side effects. As PureScript
+-- | is not lazy, the standard `ifM` has to construct both monadic actions
+-- | before returning the result, whereas here only the corresponding monadic
+-- | action is constructed.
+-- |
+-- | ```purescript
+-- | main :: Effect Unit
+-- | main = do
+-- |   response <- ifM' exists update create user
+-- |   log response
+-- |
+-- |   where
+-- |     create :: User -> Effect String
+-- |     update :: User -> Effect String
+-- |     exists :: User -> Effect Boolean
+-- | ```
+ifM' :: forall a b m. Bind m => (a -> m Boolean) -> (a -> m b) -> (a -> m b) -> a -> m b
+ifM' cond t f a = cond a >>= \cond' -> if cond' then t a else f a

--- a/src/Control/Bind.purs
+++ b/src/Control/Bind.purs
@@ -151,10 +151,9 @@ ifM :: forall a m. Bind m => m Boolean -> m a -> m a -> m a
 ifM cond t f = cond >>= \cond' -> if cond' then t else f
 
 -- | Similar to `ifM` but for use in cases where one of the monadic actions may
--- | be expensive to compute or be responsible for side effects. As PureScript
--- | is not lazy, the standard `ifM` has to construct both monadic actions
--- | before returning the result, whereas here only the corresponding monadic
--- | action is constructed.
+-- | be expensive to compute. As PureScript is not lazy, the standard `ifM` has
+-- | to construct both monadic actions before returning the result, whereas here
+-- | only the corresponding monadic action is constructed.
 -- |
 -- | ```purescript
 -- | main :: Effect Unit

--- a/src/Control/Bind.purs
+++ b/src/Control/Bind.purs
@@ -151,9 +151,7 @@ ifM :: forall a m. Bind m => m Boolean -> m a -> m a -> m a
 ifM cond t f = cond >>= \cond' -> if cond' then t else f
 
 -- | Similar to `ifM` but for use in cases where one of the monadic actions may
--- | be expensive to compute. As PureScript is not lazy, the standard `ifM` has
--- | to construct both monadic actions before returning the result, whereas here
--- | only the corresponding monadic action is constructed.
+-- | be expensive to construct.
 -- |
 -- | ```purescript
 -- | main :: Effect Unit

--- a/src/Control/Monad.purs
+++ b/src/Control/Monad.purs
@@ -62,7 +62,7 @@ liftM1 f a = do
 whenM :: forall m. Monad m => m Boolean -> m Unit -> m Unit
 whenM mb m = ifM mb m $ pure unit
 
--- | Perform a monadic action lazily when a condition is true, where the conditional
+-- | Construct a monadic action when a condition is true, where the conditional
 -- | value is also in a monadic context.
 whenM' :: forall m a. Monad m => (a -> m Boolean) -> (a -> m Unit) -> a -> m Unit
 whenM' mb m = ifM' mb m \_ -> pure unit
@@ -72,7 +72,7 @@ whenM' mb m = ifM' mb m \_ -> pure unit
 unlessM :: forall m. Monad m => m Boolean -> m Unit -> m Unit
 unlessM mb = whenM $ not <$> mb
 
--- | Perform a monadic action lazily unless a condition is true, where the conditional
+-- | Construct a monadic action unless a condition is true, where the conditional
 -- | value is also in a monadic context.
 unlessM' :: forall m a. Monad m => (a -> m Boolean) -> (a -> m Unit) -> a -> m Unit
 unlessM' mb = whenM' \x -> mb x >>= not >>> pure

--- a/src/Control/Monad.purs
+++ b/src/Control/Monad.purs
@@ -62,8 +62,8 @@ liftM1 f a = do
 whenM :: forall m. Monad m => m Boolean -> m Unit -> m Unit
 whenM mb m = ifM mb m $ pure unit
 
--- | Construct a monadic action when a condition is true, where the conditional
--- | value is also in a monadic context.
+-- | Perform a monadic action when a condition is true, without constructing it
+-- | otherwise, where the conditional value is also in a monadic context.
 whenM' :: forall m a. Monad m => (a -> m Boolean) -> (a -> m Unit) -> a -> m Unit
 whenM' mb m = ifM' mb m \_ -> pure unit
 
@@ -72,8 +72,8 @@ whenM' mb m = ifM' mb m \_ -> pure unit
 unlessM :: forall m. Monad m => m Boolean -> m Unit -> m Unit
 unlessM mb = whenM $ not <$> mb
 
--- | Construct a monadic action unless a condition is true, where the conditional
--- | value is also in a monadic context.
+-- | Perform a monadic action unless a condition is true, without constructing
+-- | it otherwise, where the conditional value is also in a monadic context.
 unlessM' :: forall m a. Monad m => (a -> m Boolean) -> (a -> m Unit) -> a -> m Unit
 unlessM' mb = whenM' \x -> mb x >>= not >>> pure
 

--- a/src/Control/Monad.purs
+++ b/src/Control/Monad.purs
@@ -65,7 +65,7 @@ whenM mb m = ifM mb m $ pure unit
 -- | Perform a monadic action lazily when a condition is true, where the conditional
 -- | value is also in a monadic context.
 whenM' :: forall m a. Monad m => (a -> m Boolean) -> (a -> m Unit) -> a -> m Unit
-whenM' mb m = ifM' mb m $ \_ -> pure unit
+whenM' mb m = ifM' mb m \_ -> pure unit
 
 -- | Perform a monadic action unless a condition is true, where the conditional
 -- | value is also in a monadic context.
@@ -75,7 +75,7 @@ unlessM mb = whenM $ not <$> mb
 -- | Perform a monadic action lazily unless a condition is true, where the conditional
 -- | value is also in a monadic context.
 unlessM' :: forall m a. Monad m => (a -> m Boolean) -> (a -> m Unit) -> a -> m Unit
-unlessM' mb = whenM' $ \x -> mb x >>= not >>> pure
+unlessM' mb = whenM' \x -> mb x >>= not >>> pure
 
 -- | `ap` provides a default implementation of `(<*>)` for any `Monad`, without
 -- | using `(<*>)` as provided by the `Apply`-`Monad` superclass relationship.

--- a/src/Prelude.purs
+++ b/src/Prelude.purs
@@ -40,11 +40,11 @@ module Prelude
   , module Data.Void
   ) where
 
-import Control.Applicative (class Applicative, pure, liftA1, unless, when)
+import Control.Applicative (class Applicative, liftA1, pure, unless, unless', when, when')
 import Control.Apply (class Apply, apply, (*>), (<*), (<*>))
-import Control.Bind (class Bind, bind, class Discard, discard, ifM, join, (<=<), (=<<), (>=>), (>>=))
+import Control.Bind (class Bind, bind, class Discard, discard, ifM, ifM', join, (<=<), (=<<), (>=>), (>>=))
 import Control.Category (class Category, identity)
-import Control.Monad (class Monad, liftM1, unlessM, whenM, ap)
+import Control.Monad (class Monad, ap, liftM1, unlessM, unlessM', whenM, whenM')
 import Control.Semigroupoid (class Semigroupoid, compose, (<<<), (>>>))
 
 import Data.Boolean (otherwise)


### PR DESCRIPTION
`ifM`, `whenM` and `unlessM` are really helpful for handling monads expressively. However, they require both of the possible outputs to be constructed. This can be problematic when the Monad is `Effect`, as PureScript is strictly evaluated, since both the side effects will still need to be constructed, even if they are not launched. This is because they may be expensive to compute especially if they use the imported JS functions.

Here is an example where a lazily evaluated version `ifM'` would be helpful:

```purs
create :: User -> Effect String
update :: User -> Effect String
exists :: User -> Effect Boolean

main :: Effect Unit
main = do
  response <- ifM' exists update create user
  log response
```

This PR creates lazy versions of each of the conditional functions for Applicatives and Monads:

- `ifM'`
- `unless'`
- `unlessM'`
- `when'`
- `whenM'`

This is following the same approach as `maybe'`:

> Similar to `maybe` but for use in cases where the default value may be
> expensive to compute. As PureScript is not lazy, the standard `maybe` has
> to evaluate the default value before returning the result, whereas here
> the value is only computed when the `Maybe` is known to be `Nothing`.

```purs
maybe' :: forall a b. (Unit -> b) -> (a -> b) -> Maybe a -> b
maybe' g _ Nothing = g unit
maybe' _ f (Just a) = f a
```

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
