### PR TITLE
Avoid `RangeError` in `arrayBind` foreign implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Avoid `RangeError` in `arrayBind` foreign implementation (#314 by @pete-murphy)
 
 Other improvements:
 

--- a/src/Control/Bind.js
+++ b/src/Control/Bind.js
@@ -1,18 +1,21 @@
-export const arrayBind = function (arr) {
-  if (typeof Array.prototype.flatMap === "function") {
-    return function (f) {
-      return arr.flatMap(f);
-    };
-  }
-
-  return function (f) {
-    const result = [];
-    for (let i = 0, l = arr.length; i < l; i++) {
-      const xs = f(arr[i]);
-      for (let j = 0, m = xs.length; j < m; j++) {
-        result.push(xs[j]);
-      }
+export const arrayBind =
+  typeof Array.prototype.flatMap === "function"
+    ? function (arr) {
+      return function (f) {
+        return arr.flatMap(f);
+      };
     }
-    return result;
-  };
-};
+    : function (arr) {
+      return function (f) {
+        var result = [];
+        var l = arr.length;
+        for (var i = 0; i < l; i++) {
+          var xs = f(arr[i]);
+          var k = xs.length;
+          for (var j = 0; j < k; j++) {
+            result.push(xs[j]);
+          }
+        }
+        return result;
+      };
+    };

--- a/src/Control/Bind.js
+++ b/src/Control/Bind.js
@@ -1,4 +1,10 @@
 export const arrayBind = function (arr) {
+  if (typeof Array.prototype.flatMap === "function") {
+    return function (f) {
+      return arr.flatMap(f);
+    };
+  }
+
   return function (f) {
     var result = [];
     for (var i = 0, l = arr.length; i < l; i++) {

--- a/src/Control/Bind.js
+++ b/src/Control/Bind.js
@@ -6,9 +6,12 @@ export const arrayBind = function (arr) {
   }
 
   return function (f) {
-    var result = [];
-    for (var i = 0, l = arr.length; i < l; i++) {
-      Array.prototype.push.apply(result, f(arr[i]));
+    const result = [];
+    for (let i = 0, l = arr.length; i < l; i++) {
+      const xs = f(arr[i]);
+      for (let j = 0, m = xs.length; j < m; j++) {
+        result.push(xs[j]);
+      }
     }
     return result;
   };

--- a/test/Test/Main.js
+++ b/test/Test/Main.js
@@ -40,3 +40,11 @@ export function testNumberShow(showNumber) {
     ]);
   };
 }
+
+export function makeArray(length) {
+  var arr = [];
+  for (var i = 0; i < length; i++) {
+    arr.push(i);
+  }
+  return arr;
+}

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -22,6 +22,7 @@ main = do
     testReflectType
     testReifyType
     testSignum
+    testArrayBind
 
 foreign import testNumberShow :: (Number -> String) -> AlmostEff
 
@@ -189,3 +190,14 @@ testSignum = do
   assert "signum positive zero" $ show (1.0/(signum 0.0)) == "Infinity"
   assert "Clarifies what 'signum negative zero' test is doing" $ show (1.0/(-0.0)) == "-Infinity"
   assert "signum negative zero" $ show (1.0/(signum (-0.0))) == "-Infinity"
+
+foreign import makeArray :: Int -> Array Int
+
+testArrayBind :: AlmostEff
+testArrayBind = do
+  assert "Array bind does not cause RangeError" do
+    let
+      _ = do
+        _ <- [unit]
+        makeArray 106_000
+    true


### PR DESCRIPTION
**Description of the change**

Fixes #309. See the [related discussion on Discourse](https://discourse.purescript.org/t/stack-safe-cartesian-product/4841).

- ec814e4c4bbc7cf43387b9fc0657a3023c069e47 adds a failing test, reproducing the issue by passing 106,000 arguments to `Array.prototype.push.apply`
- a7159c7e56cc67cd17168c439c01e661bc32bada adds a case to use `flatMap` if available in the `arrayBind` implementation
- e9ad550295918e59ba5e4e2f670ba2e5724e068f simplifies the other case, and makes it stack-safe but gives up the `Array.prototype.push.apply` optimization

I don't know the motivation behind that optimization, so I am likely not aware of the tradeoffs. I tried [some benchmarks](https://observablehq.com/d/20091fbb067cb04f) in various JS run times, not seeing wildly-different results between existing solution (`#ff725c`), `flatMap` (`#4269d0`), and simplified version added in e9ad550295918e59ba5e4e2f670ba2e5724e068f (`#efb118`):

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/f961d1ff-2ffa-442e-97f0-0d8fac63bc6e">
  <img alt="Multiple line charts showing benchmark results for three alternative implementations of arrayBind in four different JS runtimes: Safari, Firefox, Node, and Chrome" src="https://github.com/user-attachments/assets/4f95846c-cd79-4209-8ec0-2984d62ea280">
</picture>

See also #311 

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
