### PR TITLE
Remove NaN tests for Ord and Eq

### DIFF
--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -32,9 +32,6 @@ testOrd x y ord =
         ("(compare " <> show x <> " " <> show y <> " ) is not equal to " <> show ord)
         $ (compare x y) == ord
 
-nan :: Number
-nan = 0.0/0.0
-
 plusInfinity :: Number
 plusInfinity = 1.0/0.0
 
@@ -43,8 +40,6 @@ minusInfinity = -1.0/0.0
 
 testOrderings :: AlmostEff
 testOrderings = do
-    assert "NaN shouldn't be equal to itself" $ nan /= nan
-    assert "NaN shouldn't be equal to itself" $ (compare nan nan) /= EQ
     testOrd 1.0    2.0 LT
     testOrd 2.0    1.0 GT
     testOrd 1.0    (-2.0) GT
@@ -53,11 +48,6 @@ testOrderings = do
     testOrd minusInfinity 0.0 LT
     testOrd plusInfinity  0.0 GT
     testOrd plusInfinity  minusInfinity GT
-    testOrd 1.0 nan GT
-    testOrd nan 1.0 GT
-    testOrd nan plusInfinity GT
-    testOrd plusInfinity nan GT
-    assert "NaN == 1 should be false" $ nan /= 1.0
     testOrd (1 / 0) 0 EQ
     testOrd (mod 1 0) 0 EQ
     testOrd 'a' 'b' LT

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -57,10 +57,6 @@ testOrderings = do
     testOrd nan 1.0 GT
     testOrd nan plusInfinity GT
     testOrd plusInfinity nan GT
-    assert "1 > NaN should be false" $ (1.0 > nan) == false
-    assert "1 < NaN should be false" $ (1.0 < nan) == false
-    assert "NaN > 1 should be false" $ (nan > 1.0) == false
-    assert "NaN < 1 should be false" $ (nan < 1.0) == false
     assert "NaN == 1 should be false" $ nan /= 1.0
     testOrd (1 / 0) 0 EQ
     testOrd (mod 1 0) 0 EQ


### PR DESCRIPTION
These tests rely on the `purs` inliner to provide correct behavior. With this change we leave the `Ord` and `Eq` `NaN` behavior undefined. A backend can choose how comparisons with `NaN` work.

Fixes #306